### PR TITLE
Forbedret ferdigstilling & kopiering av journalposter

### DIFF
--- a/src/main/kotlin/no/nav/omsorgspenger/App.kt
+++ b/src/main/kotlin/no/nav/omsorgspenger/App.kt
@@ -22,7 +22,7 @@ import no.nav.omsorgspenger.joark.DokarkivproxyClient
 import no.nav.omsorgspenger.joark.DokarkivClient
 import no.nav.omsorgspenger.joark.SafGateway
 import no.nav.omsorgspenger.journalforjson.JournalførJsonRiver
-import no.nav.omsorgspenger.kopierjournalpost.KopierJournalpostForK9
+import no.nav.omsorgspenger.kopierjournalpost.KopierJournalpostForK9River
 import no.nav.omsorgspenger.oppgave.InitierGosysJournalføringsoppgaver
 import no.nav.omsorgspenger.oppgave.OppgaveClient
 import no.nav.omsorgspenger.oppgave.OpprettGosysJournalføringsoppgaver
@@ -52,7 +52,7 @@ internal fun RapidsConnection.registerApplicationContext(applicationContext: App
     InitierGosysJournalføringsoppgaver(
         rapidsConnection = this
     )
-    KopierJournalpostForK9(
+    KopierJournalpostForK9River(
         rapidsConnection = this,
         ferdigstillJournalføringMediator = applicationContext.ferdigstillJournalføringMediator,
         dokarkivproxyClient = applicationContext.dokarkivproxyClient,

--- a/src/main/kotlin/no/nav/omsorgspenger/App.kt
+++ b/src/main/kotlin/no/nav/omsorgspenger/App.kt
@@ -18,11 +18,13 @@ import no.nav.k9.rapid.river.hentRequiredEnv
 import no.nav.omsorgspenger.ferdigstilljournalforing.FerdigstillJournalføringForK9
 import no.nav.omsorgspenger.ferdigstilljournalforing.FerdigstillJournalføringForOmsorgspenger
 import no.nav.omsorgspenger.ferdigstilljournalforing.FerdigstillJournalføringMediator
+import no.nav.omsorgspenger.ferdigstilljournalforing.FerdigstillJournalføringRiver
 import no.nav.omsorgspenger.joark.DokarkivproxyClient
 import no.nav.omsorgspenger.joark.DokarkivClient
 import no.nav.omsorgspenger.joark.SafGateway
 import no.nav.omsorgspenger.journalforjson.JournalførJsonRiver
 import no.nav.omsorgspenger.kopierjournalpost.KopierJournalpostForK9River
+import no.nav.omsorgspenger.kopierjournalpost.KopierJournalpostRiver
 import no.nav.omsorgspenger.oppgave.InitierGosysJournalføringsoppgaver
 import no.nav.omsorgspenger.oppgave.OppgaveClient
 import no.nav.omsorgspenger.oppgave.OpprettGosysJournalføringsoppgaver
@@ -61,6 +63,16 @@ internal fun RapidsConnection.registerApplicationContext(applicationContext: App
     JournalførJsonRiver(
         rapidsConnection = this,
         dokarkivClient = applicationContext.dokarkivClient
+    )
+    FerdigstillJournalføringRiver(
+        rapidsConnection = this,
+        dokarkivClient = applicationContext.dokarkivClient,
+        safGateway = applicationContext.safGateway
+    )
+    KopierJournalpostRiver(
+        rapidsConnection = this,
+        dokarkivproxyClient = applicationContext.dokarkivproxyClient,
+        safGateway = applicationContext.safGateway
     )
 
     register(object : RapidsConnection.StatusListener {

--- a/src/main/kotlin/no/nav/omsorgspenger/ferdigstilljournalforing/AbstractFerdigstillJournalføring.kt
+++ b/src/main/kotlin/no/nav/omsorgspenger/ferdigstilljournalforing/AbstractFerdigstillJournalføring.kt
@@ -13,12 +13,12 @@ import no.nav.omsorgspenger.Saksnummer.Companion.somSaksnummer
 import no.nav.omsorgspenger.ferdigstilljournalforing.JournalpostManglerNavn.behandlaJournalpostHåndterManglerNavn
 import org.slf4j.LoggerFactory
 
-internal abstract class FerdigstillJournalføring(
+internal abstract class AbstractFerdigstillJournalføring(
     rapidsConnection: RapidsConnection,
     private val ferdigstillJournalføringMediator: FerdigstillJournalføringMediator,
     private val behov: String,
     private val fagsystem: Fagsystem) : BehovssekvensPacketListener(
-    logger = LoggerFactory.getLogger(FerdigstillJournalføring::class.java)) {
+    logger = LoggerFactory.getLogger(AbstractFerdigstillJournalføring::class.java)) {
 
     private val JOURNALPOSTIDER = "@behov.$behov.journalpostIder"
     private val IDENTITETSNUMMER = "@behov.$behov.identitetsnummer"

--- a/src/main/kotlin/no/nav/omsorgspenger/ferdigstilljournalforing/FerdigstillJournalføringForK9.kt
+++ b/src/main/kotlin/no/nav/omsorgspenger/ferdigstilljournalforing/FerdigstillJournalføringForK9.kt
@@ -6,7 +6,7 @@ import no.nav.omsorgspenger.Fagsystem
 internal class FerdigstillJournalføringForK9(
     rapidsConnection: RapidsConnection,
     ferdigstillJournalføringMediator: FerdigstillJournalføringMediator
-) : FerdigstillJournalføring(
+) : AbstractFerdigstillJournalføring(
     rapidsConnection = rapidsConnection,
     ferdigstillJournalføringMediator = ferdigstillJournalføringMediator,
     behov = "FerdigstillJournalføringForK9",

--- a/src/main/kotlin/no/nav/omsorgspenger/ferdigstilljournalforing/FerdigstillJournalføringForOmsorgspenger.kt
+++ b/src/main/kotlin/no/nav/omsorgspenger/ferdigstilljournalforing/FerdigstillJournalføringForOmsorgspenger.kt
@@ -6,7 +6,7 @@ import no.nav.omsorgspenger.Fagsystem
 internal class FerdigstillJournalføringForOmsorgspenger(
     rapidsConnection: RapidsConnection,
     ferdigstillJournalføringMediator: FerdigstillJournalføringMediator
-) : FerdigstillJournalføring(
+) : AbstractFerdigstillJournalføring(
     rapidsConnection = rapidsConnection,
     ferdigstillJournalføringMediator = ferdigstillJournalføringMediator,
     behov = "FerdigstillJournalføringForOmsorgspenger",

--- a/src/main/kotlin/no/nav/omsorgspenger/ferdigstilljournalforing/FerdigstillJournalføringMelding.kt
+++ b/src/main/kotlin/no/nav/omsorgspenger/ferdigstilljournalforing/FerdigstillJournalføringMelding.kt
@@ -1,0 +1,75 @@
+package no.nav.omsorgspenger.ferdigstilljournalforing
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.node.TextNode
+import no.nav.helse.rapids_rivers.JsonMessage
+import no.nav.helse.rapids_rivers.isMissingOrNull
+import no.nav.k9.rapid.behov.Behov
+import no.nav.k9.rapid.river.aktueltBehov
+import no.nav.k9.rapid.river.leggTilBehov
+import no.nav.k9.rapid.river.requireArray
+import no.nav.omsorgspenger.Fagsystem
+import no.nav.omsorgspenger.Identitetsnummer
+import no.nav.omsorgspenger.Identitetsnummer.Companion.somIdentitetsnummer
+import no.nav.omsorgspenger.JournalpostId
+import no.nav.omsorgspenger.JournalpostId.Companion.somJournalpostId
+import no.nav.omsorgspenger.Saksnummer
+import no.nav.omsorgspenger.Saksnummer.Companion.somSaksnummer
+
+internal object FerdigstillJournalføringMelding {
+
+    internal data class FerdigstillJournalføring(
+        internal val versjon: String,
+        internal val journalpostIder: Set<JournalpostId>,
+        internal val identitetsnummer: Identitetsnummer,
+        internal val saksnummer: Saksnummer,
+        internal val fagsystem: Fagsystem,
+        internal val navn: String?
+    )
+
+    internal fun validateBehov(
+        packet: JsonMessage,
+        aktueltBehov: String) {
+        packet.require(aktueltBehov.journalpostIder()) { it.requireArray { entry -> entry is TextNode } }
+        packet.require(aktueltBehov.identitetsnummer(), JsonNode::asText)
+        packet.require(aktueltBehov.saksnummer(), JsonNode::asText)
+        packet.require(aktueltBehov.fagsystem(), JsonNode::asText)
+        packet.interestedIn(personopplysninger)
+    }
+
+    internal fun hentBehov(
+        packet: JsonMessage,
+        aktueltBehov: String = packet.aktueltBehov()) : FerdigstillJournalføring {
+        val identitetsnummer = packet[aktueltBehov.identitetsnummer()].asText().somIdentitetsnummer()
+        return FerdigstillJournalføring(
+            versjon = packet[aktueltBehov.versjon()].asText(),
+            journalpostIder = packet[aktueltBehov.journalpostIder()].map { it.asText().somJournalpostId() }.toSet(),
+            identitetsnummer = identitetsnummer,
+            saksnummer = packet[aktueltBehov.saksnummer()].asText().somSaksnummer(),
+            fagsystem = Fagsystem.valueOf(packet[aktueltBehov.fagsystem()].asText()),
+            navn = when (packet[personopplysninger].isMissingOrNull()) {
+                true -> null
+                false -> packet[personopplysninger].get("$identitetsnummer").get("navn").get("sammensatt").asText()
+            })
+    }
+
+    internal fun leggTilBehovForNavn(packet: JsonMessage, aktueltBehov: String, identitetsnummer: Identitetsnummer) {
+        packet.leggTilBehov(aktueltBehov,
+            Behov(navn = hentPersonopplysningerBehov, input = mapOf(
+                "attributter" to listOf("navn"),
+                "identitetsnummer" to listOf("$identitetsnummer"),
+                "måFinneAllePersoner" to true
+            ))
+        )
+    }
+
+    internal const val behovNavn = "FerdigstillJournalføring"
+    private const val hentPersonopplysningerBehov = "HentPersonopplysninger@ferdigstillJournalføring"
+
+    private fun String.journalpostIder() = "@behov.$this.journalpostIder"
+    private fun String.identitetsnummer() = "@behov.$this.identitetsnummer"
+    private fun String.saksnummer() = "@behov.$this.saksnummer"
+    private fun String.versjon() = "@behov.$this.versjon"
+    private fun String.fagsystem() = "@behov.$this.fagsystem"
+    private const val personopplysninger = "@løsninger.$hentPersonopplysningerBehov.personopplysninger"
+}

--- a/src/main/kotlin/no/nav/omsorgspenger/ferdigstilljournalforing/FerdigstillJournalføringMelding.kt
+++ b/src/main/kotlin/no/nav/omsorgspenger/ferdigstilljournalforing/FerdigstillJournalføringMelding.kt
@@ -34,6 +34,7 @@ internal object FerdigstillJournalføringMelding {
         packet.require(aktueltBehov.identitetsnummer(), JsonNode::asText)
         packet.require(aktueltBehov.saksnummer(), JsonNode::asText)
         packet.require(aktueltBehov.fagsystem(), JsonNode::asText)
+        packet.require(aktueltBehov.versjon(), JsonNode::asText)
         packet.interestedIn(personopplysninger)
     }
 

--- a/src/main/kotlin/no/nav/omsorgspenger/ferdigstilljournalforing/FerdigstillJournalføringRiver.kt
+++ b/src/main/kotlin/no/nav/omsorgspenger/ferdigstilljournalforing/FerdigstillJournalføringRiver.kt
@@ -1,0 +1,82 @@
+package no.nav.omsorgspenger.ferdigstilljournalforing
+
+import kotlinx.coroutines.runBlocking
+import no.nav.helse.rapids_rivers.JsonMessage
+import no.nav.helse.rapids_rivers.RapidsConnection
+import no.nav.helse.rapids_rivers.River
+import no.nav.k9.rapid.river.*
+import no.nav.omsorgspenger.CorrelationId.Companion.correlationId
+import no.nav.omsorgspenger.joark.DokarkivClient
+import no.nav.omsorgspenger.joark.FerdigstillJournalpost
+import no.nav.omsorgspenger.joark.SafGateway
+import org.slf4j.LoggerFactory
+
+internal class FerdigstillJournalføringRiver(
+    rapidsConnection: RapidsConnection,
+    private val safGateway: SafGateway,
+    private val dokarkivClient: DokarkivClient
+) : BehovssekvensPacketListener(
+    logger = LoggerFactory.getLogger(FerdigstillJournalføringRiver::class.java)) {
+
+    init {
+        River(rapidsConnection).apply {
+            validate { packet ->
+                packet.skalLøseBehov(FerdigstillJournalføringMelding.behovNavn)?.also { aktueltBehov ->
+                    FerdigstillJournalføringMelding.validateBehov(packet, aktueltBehov)
+                }
+            }
+        }.register(this)
+    }
+
+    override fun doHandlePacket(id: String, packet: JsonMessage): Boolean {
+        val ferdigstillJournalføring = FerdigstillJournalføringMelding.hentBehov(packet)
+        return (ferdigstillJournalføring.versjon == "1.0.0").also { if (!it) {
+            logger.warn("Støtter ikke ${FerdigstillJournalføringMelding.behovNavn} på versjon ${ferdigstillJournalføring.versjon}")
+        }}
+    }
+
+    override fun handlePacket(id: String, packet: JsonMessage): Boolean {
+        val aktueltBehov = packet.aktueltBehov()
+        val correlationId = packet.correlationId()
+        val behov = FerdigstillJournalføringMelding.hentBehov(packet, aktueltBehov)
+
+        logger.info("Ferdigstiller JournalpostIder=${behov.journalpostIder} for Fagsystem=[${behov.fagsystem.name}] & Saksnummer=[${behov.saksnummer}]")
+
+        val ferdigstillJournalposter = behov.journalpostIder.map { journalpostId -> runBlocking { safGateway.hentFerdigstillJournalpost(
+            correlationId = correlationId,
+            journalpostId = journalpostId
+        )}}.filterNot { ferdigstillJournalpost ->
+            ferdigstillJournalpost.erFerdigstilt.also { logger.info("JournalpostId=[${ferdigstillJournalpost.journalpostId}] er allerede ferdigstilt.")
+        }}.map { it.copy(
+            bruker = FerdigstillJournalpost.Bruker(
+                identitetsnummer = behov.identitetsnummer,
+                sak = behov.fagsystem to behov.saksnummer,
+                navn = behov.navn
+            )
+        )}
+
+        val manglerAvsendernavn = ferdigstillJournalposter.filter { it.manglerAvsendernavn() }
+        // Legger til behov for å hente navn på brukeren om det vi mangler avsendernavn
+        if (manglerAvsendernavn.isNotEmpty()) {
+            logger.info("Mangler avsendernavn på JournalpostIder=${manglerAvsendernavn.map { it.journalpostId }}. Legger til behov for å hente navn på bruker.")
+            FerdigstillJournalføringMelding.leggTilBehovForNavn(
+                packet = packet,
+                aktueltBehov = aktueltBehov,
+                identitetsnummer = behov.identitetsnummer
+            )
+            return true
+        }
+
+        // Alle journalposter klare til oppdatering & ferdigstilling
+        check(ferdigstillJournalposter.all { it.kanFerdigstilles })
+
+        runBlocking { ferdigstillJournalposter.forEach { ferdigstillJournalpost ->
+            dokarkivClient.oppdaterJournalpostForFerdigstilling(correlationId, ferdigstillJournalpost)
+            dokarkivClient.ferdigstillJournalpost(correlationId, ferdigstillJournalpost)
+        }}
+
+        logger.info("Alle journalposter ferdigstilt.")
+        packet.leggTilLøsning(aktueltBehov)
+        return true
+    }
+}

--- a/src/main/kotlin/no/nav/omsorgspenger/ferdigstilljournalforing/FerdigstillJournalføringRiver.kt
+++ b/src/main/kotlin/no/nav/omsorgspenger/ferdigstilljournalforing/FerdigstillJournalføringRiver.kt
@@ -72,7 +72,7 @@ internal class FerdigstillJournalføringRiver(
 
         runBlocking { ferdigstillJournalposter.forEach { ferdigstillJournalpost ->
             dokarkivClient.oppdaterJournalpostForFerdigstilling(correlationId, ferdigstillJournalpost)
-            dokarkivClient.ferdigstillJournalpost(correlationId, ferdigstillJournalpost)
+            dokarkivClient.ferdigstillJournalposten(correlationId, ferdigstillJournalpost)
         }}
 
         logger.info("Alle journalposter ferdigstilt.")

--- a/src/main/kotlin/no/nav/omsorgspenger/joark/DokarkivClient.kt
+++ b/src/main/kotlin/no/nav/omsorgspenger/joark/DokarkivClient.kt
@@ -121,7 +121,7 @@ internal class DokarkivClient(
         }
     }
 
-    internal suspend fun ferdigstillJournalpost(
+    internal suspend fun ferdigstillJournalposten(
         correlationId: CorrelationId,
         ferdigstillJournalpost: FerdigstillJournalpost) {
         val url = ferdigstillJournalpost.journalpostId.ferdigstillJournalpostUrl()

--- a/src/main/kotlin/no/nav/omsorgspenger/joark/DokarkivClient.kt
+++ b/src/main/kotlin/no/nav/omsorgspenger/joark/DokarkivClient.kt
@@ -54,7 +54,7 @@ internal class DokarkivClient(
         return kotlin.runCatching {
             httpClient.put<HttpStatement>("$baseUrl/rest/journalpostapi/v1/journalpost/${journalpost.journalpostId}") {
                 header("Nav-Callid", correlationId)
-                header("Nav-Consumer-Id", ConsumerId)
+                header("Nav-Consumer-Id", "omsorgspenger-journalforing")
                 header("Authorization", authorizationHeader())
                 contentType(ContentType.Application.Json)
                 body = payload
@@ -75,7 +75,7 @@ internal class DokarkivClient(
         return kotlin.runCatching {
             httpClient.patch<HttpStatement>("$baseUrl/rest/journalpostapi/v1/journalpost/${journalpostId}/ferdigstill") {
                 header("Nav-Callid", correlationId)
-                header("Nav-Consumer-Id", ConsumerId)
+                header("Nav-Consumer-Id", "omsorgspenger-journalforing")
                 header("Authorization", authorizationHeader())
                 contentType(ContentType.Application.Json)
                 body = payload
@@ -137,7 +137,7 @@ internal class DokarkivClient(
 
     private fun HttpRequestBuilder.defaultHeaders(correlationId: CorrelationId) {
         header("Nav-Callid", "$correlationId")
-        header("Nav-Consumer-Id", ConsumerId)
+        header("Nav-Consumer-Id", "omsorgspenger-journalforing")
         header("Authorization", authorizationHeader())
     }
 
@@ -161,8 +161,6 @@ internal class DokarkivClient(
 
     private companion object {
         private val secureLogger = LoggerFactory.getLogger("tjenestekall")
-
-        private const val ConsumerId = "omsorgspenger-journalforing"
 
         private fun String.json() = kotlin.runCatching { JSONObject(this) }.fold(
             onSuccess = { it },

--- a/src/main/kotlin/no/nav/omsorgspenger/joark/DokarkivClient.kt
+++ b/src/main/kotlin/no/nav/omsorgspenger/joark/DokarkivClient.kt
@@ -2,16 +2,14 @@ package no.nav.omsorgspenger.joark
 
 import io.ktor.client.HttpClient
 import io.ktor.client.features.ResponseException
-import io.ktor.client.request.header
-import io.ktor.client.request.patch
-import io.ktor.client.request.put
+import io.ktor.client.request.*
 import io.ktor.client.statement.HttpResponse
 import io.ktor.client.statement.HttpStatement
-import io.ktor.http.ContentType
-import io.ktor.http.HttpStatusCode
-import io.ktor.http.contentType
+import io.ktor.http.*
 import io.ktor.util.toByteArray
+import no.nav.helse.dusseldorf.ktor.client.SimpleHttpClient.httpPatch
 import no.nav.helse.dusseldorf.ktor.client.SimpleHttpClient.httpPost
+import no.nav.helse.dusseldorf.ktor.client.SimpleHttpClient.httpPut
 import no.nav.helse.dusseldorf.ktor.client.SimpleHttpClient.jsonBody
 import no.nav.helse.dusseldorf.ktor.client.SimpleHttpClient.readTextOrThrow
 import no.nav.helse.dusseldorf.oauth2.client.AccessTokenClient
@@ -45,6 +43,8 @@ internal class DokarkivClient(
 
     private val baseUrl = env.hentRequiredEnv("DOKARKIV_BASE_URL")
     private val opprettJournalpostUrl = "$baseUrl/rest/journalpostapi/v1/journalpost?forsoekFerdigstill=true"
+    private fun JournalpostId.oppdaterJournalpostUrl() = "$baseUrl/rest/journalpostapi/v1/journalpost/${this}"
+    private fun JournalpostId.ferdigstillJournalpostUrl() = "$baseUrl/rest/journalpostapi/v1/journalpost/${this}/ferdigstill"
 
     internal suspend fun oppdaterJournalpost(correlationId: String, journalpost: Journalpost) : JournalpostStatus {
         val payload = journalpost.oppdatertJournalpostBody().also {
@@ -91,9 +91,7 @@ internal class DokarkivClient(
         nyJournalpost: NyJournalpost
     ): JournalpostId {
         val (httpStatus, responseBody) = opprettJournalpostUrl.httpPost { builder ->
-            builder.header("Nav-Callid", "$correlationId")
-            builder.header("Nav-Consumer-Id", ConsumerId)
-            builder.header("Authorization", authorizationHeader())
+            builder.defaultHeaders(correlationId)
             builder.jsonBody(nyJournalpost.dokarkivPayload())
         }.readTextOrThrow()
 
@@ -107,6 +105,40 @@ internal class DokarkivClient(
             }
             false -> throw IllegalStateException("Feil ved opprettelse av journalpost. HttpStatus=[${httpStatus.value}], Response=[$responseBody]")
         }
+    }
+
+    internal suspend fun oppdaterJournalpostForFerdigstilling(
+        correlationId: CorrelationId,
+        ferdigstillJournalpost: FerdigstillJournalpost) {
+        val url = ferdigstillJournalpost.journalpostId.oppdaterJournalpostUrl()
+        val (httpStatus, responseBody) = url.httpPut { builder ->
+            builder.defaultHeaders(correlationId)
+            builder.jsonBody(ferdigstillJournalpost.oppdaterPayload())
+        }.readTextOrThrow()
+
+        check(httpStatus.isSuccess()) {
+            "Feil ved oppdatering av journalpost. HttpStatus=[${httpStatus.value}, Response=[$responseBody], Url=[$url]"
+        }
+    }
+
+    internal suspend fun ferdigstillJournalpost(
+        correlationId: CorrelationId,
+        ferdigstillJournalpost: FerdigstillJournalpost) {
+        val url = ferdigstillJournalpost.journalpostId.ferdigstillJournalpostUrl()
+        val (httpStatus, responseBody) = url.httpPatch { builder ->
+            builder.defaultHeaders(correlationId)
+            builder.jsonBody(ferdigstillJournalpost.ferdigstillPayload())
+        }.readTextOrThrow()
+
+        check(httpStatus.isSuccess()) {
+            "Feil ved ferdigstilling av journalpost. HttpStatus=[${httpStatus.value}, Response=[$responseBody], Url=[$url]"
+        }
+    }
+
+    private fun HttpRequestBuilder.defaultHeaders(correlationId: CorrelationId) {
+        header("Nav-Callid", "$correlationId")
+        header("Nav-Consumer-Id", ConsumerId)
+        header("Authorization", authorizationHeader())
     }
 
     private suspend fun Result<HttpResponse>.håndterResponseFraJoark(

--- a/src/main/kotlin/no/nav/omsorgspenger/joark/FerdigstillJournalpost.kt
+++ b/src/main/kotlin/no/nav/omsorgspenger/joark/FerdigstillJournalpost.kt
@@ -5,6 +5,7 @@ import no.nav.omsorgspenger.Identitetsnummer
 import no.nav.omsorgspenger.JournalpostId
 import no.nav.omsorgspenger.Saksnummer
 import org.intellij.lang.annotations.Language
+import org.json.JSONArray
 import org.json.JSONObject
 
 internal data class FerdigstillJournalpost(
@@ -52,9 +53,12 @@ internal data class FerdigstillJournalpost(
         if (tittel.isNullOrBlank()) { json.put("tittel", ManglerTittel) }
         // Mangler tittel på et eller fler dokumenter
         dokumenter.filter { it.tittel.isNullOrBlank() }.takeIf { it.isNotEmpty() }?.also { dokumenterUtenTittel ->
-            val jsonDokumenter = JSONObject()
+            val jsonDokumenter = JSONArray()
             dokumenterUtenTittel.forEach { dokumentUtenTittel ->
-                jsonDokumenter.put(dokumentUtenTittel.dokumentId, JSONObject().also { it.put("tittel", ManglerTittel) })
+                jsonDokumenter.put(JSONObject().also {
+                    it.put("dokumentInfoId", dokumentUtenTittel.dokumentId)
+                    it.put("tittel", ManglerTittel)
+                })
             }
             json.put("dokumenter", jsonDokumenter)
         }

--- a/src/main/kotlin/no/nav/omsorgspenger/joark/FerdigstillJournalpost.kt
+++ b/src/main/kotlin/no/nav/omsorgspenger/joark/FerdigstillJournalpost.kt
@@ -1,0 +1,94 @@
+package no.nav.omsorgspenger.joark
+
+import no.nav.omsorgspenger.Fagsystem
+import no.nav.omsorgspenger.Identitetsnummer
+import no.nav.omsorgspenger.JournalpostId
+import no.nav.omsorgspenger.Saksnummer
+import org.intellij.lang.annotations.Language
+import org.json.JSONObject
+
+internal data class FerdigstillJournalpost(
+    internal val journalpostId: JournalpostId,
+    private val status: JoarkTyper.JournalpostStatus,
+    private val avsendernavn: String? = null,
+    private val tittel: String? = null,
+    private val dokumenter: Set<Dokument> = emptySet(),
+    private val bruker: Bruker? = null) {
+
+    private val mangler = mutableListOf<Mangler>().also { alleMangler ->
+        if (bruker == null) { alleMangler.add(Mangler.Bruker) }
+        if (avsendernavn.isNullOrBlank() && bruker?.navn.isNullOrBlank()) { alleMangler.add(Mangler.Avsendernavn) }
+    }.toList()
+
+    internal val erFerdigstilt = status.erFerdigstilt || status.erJournalført
+    internal val kanFerdigstilles = !erFerdigstilt && mangler.isEmpty()
+
+    private fun mangler() : List<Mangler> {
+        check(!erFerdigstilt) { "Journalpost $journalpostId er allerede ferdigstilt." }
+        return mangler
+    }
+
+    internal fun manglerAvsendernavn() = mangler().contains(Mangler.Avsendernavn)
+
+    internal fun oppdaterPayload() : String {
+        check(kanFerdigstilles) { "Journalposten $journalpostId kan ikke ferdigstilles." }
+        @Language("JSON")
+        val json = """
+        {
+          "tema": "OMS",
+          "bruker": {
+            "idType": "FNR",
+            "id": "${bruker!!.identitetsnummer}"
+          },
+          "sak": {
+            "sakstype": "FAGSAK",
+            "fagsaksystem": "${bruker.sak.first.name}",
+            "fagsakId": "${bruker.sak.second}"
+          }
+        }
+        """.trimIndent().let { JSONObject(it) }
+
+        // Mangler tittel på journalposten
+        if (tittel.isNullOrBlank()) { json.put("tittel", ManglerTittel) }
+        // Mangler tittel på et eller fler dokumenter
+        dokumenter.filter { it.tittel.isNullOrBlank() }.takeIf { it.isNotEmpty() }?.also { dokumenterUtenTittel ->
+            val jsonDokumenter = JSONObject()
+            dokumenterUtenTittel.forEach { dokumentUtenTittel ->
+                json.put(dokumentUtenTittel.dokumentId, JSONObject().also { it.put("tittel", ManglerTittel) })
+            }
+            json.put("dokumenter", jsonDokumenter)
+        }
+        // Mangler navn på avsender
+        if (avsendernavn.isNullOrBlank()) {
+            json.put("avsenderMottaker", JSONObject().also { it.put("navn", bruker.navn!!) })
+        }
+        return json.toString()
+    }
+
+    internal fun ferdigstillPayload() : String {
+        check(kanFerdigstilles) { "Journalposten $journalpostId kan ikke ferdigstilles." }
+        return FerdigstillPayload
+    }
+
+    internal data class Bruker(
+        internal val identitetsnummer: Identitetsnummer,
+        internal val sak: Pair<Fagsystem, Saksnummer>,
+        internal val navn: String?
+    )
+
+    internal data class Dokument(
+        internal val dokumentId: String,
+        internal val tittel: String?
+    )
+
+    internal enum class Mangler {
+        Bruker,
+        Avsendernavn
+    }
+
+    private companion object {
+        private const val ManglerTittel = "Mangler tittel"
+        @Language("JSON")
+        private const val FerdigstillPayload = """{"journalfoerendeEnhet": "9999"}"""
+    }
+}

--- a/src/main/kotlin/no/nav/omsorgspenger/joark/FerdigstillJournalpost.kt
+++ b/src/main/kotlin/no/nav/omsorgspenger/joark/FerdigstillJournalpost.kt
@@ -54,7 +54,7 @@ internal data class FerdigstillJournalpost(
         dokumenter.filter { it.tittel.isNullOrBlank() }.takeIf { it.isNotEmpty() }?.also { dokumenterUtenTittel ->
             val jsonDokumenter = JSONObject()
             dokumenterUtenTittel.forEach { dokumentUtenTittel ->
-                json.put(dokumentUtenTittel.dokumentId, JSONObject().also { it.put("tittel", ManglerTittel) })
+                jsonDokumenter.put(dokumentUtenTittel.dokumentId, JSONObject().also { it.put("tittel", ManglerTittel) })
             }
             json.put("dokumenter", jsonDokumenter)
         }

--- a/src/main/kotlin/no/nav/omsorgspenger/joark/JoarkTyper.kt
+++ b/src/main/kotlin/no/nav/omsorgspenger/joark/JoarkTyper.kt
@@ -4,6 +4,8 @@ internal object JoarkTyper {
     internal data class JournalpostStatus private constructor(private val value: String) {
         override fun toString() = value
         internal val erJournalført = value == "JOURNALFOERT"
+        internal val erFerdigstilt = value == "FERDIGSTILT"
+        internal val erMottatt = value == "MOTTATT"
         internal companion object {
             internal fun String.somJournalpostStatus() = JournalpostStatus(this)
         }
@@ -12,6 +14,7 @@ internal object JoarkTyper {
     internal data class JournalpostType private constructor(private val value: String) {
         override fun toString() = value
         internal val erInngående = value == "I"
+        internal val erNotat = value == "N"
         internal companion object {
             internal fun String.somJournalpostType() = JournalpostType(this)
         }

--- a/src/main/kotlin/no/nav/omsorgspenger/joark/JoarkTyper.kt
+++ b/src/main/kotlin/no/nav/omsorgspenger/joark/JoarkTyper.kt
@@ -1,0 +1,19 @@
+package no.nav.omsorgspenger.joark
+
+internal object JoarkTyper {
+    internal data class JournalpostStatus private constructor(private val value: String) {
+        override fun toString() = value
+        internal val erJournalført = value == "JOURNALFOERT"
+        internal companion object {
+            internal fun String.somJournalpostStatus() = JournalpostStatus(this)
+        }
+    }
+
+    internal data class JournalpostType private constructor(private val value: String) {
+        override fun toString() = value
+        internal val erInngående = value == "I"
+        internal companion object {
+            internal fun String.somJournalpostType() = JournalpostType(this)
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/omsorgspenger/joark/JoarkTyper.kt
+++ b/src/main/kotlin/no/nav/omsorgspenger/joark/JoarkTyper.kt
@@ -5,7 +5,6 @@ internal object JoarkTyper {
         override fun toString() = value
         internal val erJournalført = value == "JOURNALFOERT"
         internal val erFerdigstilt = value == "FERDIGSTILT"
-        internal val erMottatt = value == "MOTTATT"
         internal companion object {
             internal fun String.somJournalpostStatus() = JournalpostStatus(this)
         }

--- a/src/main/kotlin/no/nav/omsorgspenger/joark/SafGateway.kt
+++ b/src/main/kotlin/no/nav/omsorgspenger/joark/SafGateway.kt
@@ -12,6 +12,8 @@ import no.nav.omsorgspenger.Fagsystem
 import no.nav.omsorgspenger.JournalpostId
 import no.nav.omsorgspenger.JournalpostId.Companion.somJournalpostId
 import no.nav.omsorgspenger.Saksnummer
+import no.nav.omsorgspenger.joark.JoarkTyper.JournalpostStatus.Companion.somJournalpostStatus
+import no.nav.omsorgspenger.joark.JoarkTyper.JournalpostType.Companion.somJournalpostType
 import org.json.JSONObject
 import java.net.URI
 import java.time.LocalDate
@@ -41,10 +43,10 @@ internal class SafGateway(
             builder.header(HttpHeaders.Authorization, authorizationHeader())
             builder.jsonBody(
                 hentOriginalJournalpostIderQuery(
-                fagsystem = fagsystem,
-                saksnummer = saksnummer,
-                fraOgMed = fraOgMed
-            )
+                    fagsystem = fagsystem,
+                    saksnummer = saksnummer,
+                    fraOgMed = fraOgMed
+                )
             )
         }.readTextOrThrow()
 
@@ -53,6 +55,12 @@ internal class SafGateway(
         }
 
         return response.mapOriginaleJournalpostIderResponse()
+    }
+
+    internal suspend fun hentTypeOgStatus(
+        journalpostId: JournalpostId,
+        correlationId: CorrelationId) : Pair<JoarkTyper.JournalpostType, JoarkTyper.JournalpostStatus> {
+        return "I".somJournalpostType() to "JOURNALFOERT".somJournalpostStatus()
     }
 
     internal companion object {

--- a/src/main/kotlin/no/nav/omsorgspenger/joark/SafGateway.kt
+++ b/src/main/kotlin/no/nav/omsorgspenger/joark/SafGateway.kt
@@ -57,10 +57,22 @@ internal class SafGateway(
         return response.mapOriginaleJournalpostIderResponse()
     }
 
+    // TODO: Legge til integrasjon mot SAF
     internal suspend fun hentTypeOgStatus(
         journalpostId: JournalpostId,
         correlationId: CorrelationId) : Pair<JoarkTyper.JournalpostType, JoarkTyper.JournalpostStatus> {
-        return "I".somJournalpostType() to "JOURNALFOERT".somJournalpostStatus()
+        return "I".somJournalpostType() to "MOTTATT".somJournalpostStatus()
+    }
+
+    // TODO: Legge til integrasjon mot SAF
+    internal suspend fun hentFerdigstillJournalpost(
+        correlationId: CorrelationId,
+        journalpostId: JournalpostId
+    ) : FerdigstillJournalpost {
+        return FerdigstillJournalpost(
+            journalpostId = journalpostId,
+            status = "MOTTATT".somJournalpostStatus()
+        )
     }
 
     internal companion object {

--- a/src/main/kotlin/no/nav/omsorgspenger/journalforjson/HtmlGenerator.kt
+++ b/src/main/kotlin/no/nav/omsorgspenger/journalforjson/HtmlGenerator.kt
@@ -92,8 +92,8 @@ internal object HtmlGenerator {
         var wasDigit = false
         forEachIndexed { index, char ->
             reverted += when {
-                index == 0 -> char.toUpperCase()
-                char.isUpperCase() -> " ${char.toLowerCase()}"
+                index == 0 -> char.uppercase()
+                char.isUpperCase() -> " ${char.lowercase()}"
                 char.isDigit() && !wasDigit -> " $char"
                 else -> char
             }

--- a/src/main/kotlin/no/nav/omsorgspenger/kopierjournalpost/AbstractKopierJournalpostRiver.kt
+++ b/src/main/kotlin/no/nav/omsorgspenger/kopierjournalpost/AbstractKopierJournalpostRiver.kt
@@ -24,7 +24,7 @@ import no.nav.omsorgspenger.ferdigstilljournalforing.JournalpostManglerNavn.beha
 import org.slf4j.LoggerFactory
 import java.time.ZonedDateTime
 
-internal abstract class KopierJournalpost(
+internal abstract class AbstractKopierJournalpostRiver(
     rapidsConnection: RapidsConnection,
     private val ferdigstillJournalføringMediator: FerdigstillJournalføringMediator,
     private val dokarkivproxyClient: DokarkivproxyClient,
@@ -32,7 +32,7 @@ internal abstract class KopierJournalpost(
     private val fagsystem: Fagsystem,
     private val behov: String
 ) : BehovssekvensPacketListener(
-    logger = LoggerFactory.getLogger(KopierJournalpost::class.java)) {
+    logger = LoggerFactory.getLogger(AbstractKopierJournalpostRiver::class.java)) {
 
     private val JournalpostIdKey = "@behov.$behov.journalpostId"
     private val VersjonKey = "@behov.$behov.versjon"

--- a/src/main/kotlin/no/nav/omsorgspenger/kopierjournalpost/KopierJournalpostForK9River.kt
+++ b/src/main/kotlin/no/nav/omsorgspenger/kopierjournalpost/KopierJournalpostForK9River.kt
@@ -6,12 +6,12 @@ import no.nav.omsorgspenger.Fagsystem
 import no.nav.omsorgspenger.joark.SafGateway
 import no.nav.omsorgspenger.ferdigstilljournalforing.FerdigstillJournalføringMediator
 
-internal class KopierJournalpostForK9(
+internal class KopierJournalpostForK9River(
     rapidsConnection: RapidsConnection,
     ferdigstillJournalføringMediator: FerdigstillJournalføringMediator,
     dokarkivproxyClient: DokarkivproxyClient,
     safGateway: SafGateway
-) : KopierJournalpost(
+) : AbstractKopierJournalpostRiver(
     rapidsConnection = rapidsConnection,
     ferdigstillJournalføringMediator = ferdigstillJournalføringMediator,
     dokarkivproxyClient = dokarkivproxyClient,

--- a/src/main/kotlin/no/nav/omsorgspenger/kopierjournalpost/KopierJournalpostMelding.kt
+++ b/src/main/kotlin/no/nav/omsorgspenger/kopierjournalpost/KopierJournalpostMelding.kt
@@ -1,7 +1,9 @@
 package no.nav.omsorgspenger.kopierjournalpost
 
 import no.nav.helse.rapids_rivers.JsonMessage
-import no.nav.helse.rapids_rivers.isMissingOrNull
+import no.nav.k9.rapid.behov.Behov
+import no.nav.k9.rapid.river.aktueltBehov
+import no.nav.k9.rapid.river.leggTilBehov
 import no.nav.k9.rapid.river.leggTilLøsning
 import no.nav.omsorgspenger.Fagsystem
 import no.nav.omsorgspenger.Identitetsnummer
@@ -10,38 +12,50 @@ import no.nav.omsorgspenger.JournalpostId
 import no.nav.omsorgspenger.JournalpostId.Companion.somJournalpostId
 import no.nav.omsorgspenger.Saksnummer
 import no.nav.omsorgspenger.Saksnummer.Companion.somSaksnummer
+import no.nav.omsorgspenger.ferdigstilljournalforing.FerdigstillJournalføringMelding
 
 internal object KopierJournalpostMelding {
 
-    internal fun validateBehov(packet: JsonMessage, aktueltBehov: String) {
+    internal data class KopierJournalpost(
+        internal val versjon: String,
+        internal val journalpostId: JournalpostId,
+        internal val fraIdentitetsnummer: Identitetsnummer,
+        internal val fraSaksnummer: Saksnummer,
+        internal val tilIdentitetsnummer: Identitetsnummer,
+        internal val tilSaksnummer: Saksnummer,
+        internal val fagsystem: Fagsystem
+    )
+
+    internal fun validateBehov(
+        packet: JsonMessage,
+        aktueltBehov: String) {
         packet.requireKey(
+            aktueltBehov.versjon(),
             aktueltBehov.tilIdentitetsnummer(),
             aktueltBehov.tilSaksnummer(),
             aktueltBehov.journalpostId(),
-            aktueltBehov.fagsystem()
-        )
-        packet.interestedIn(
+            aktueltBehov.fagsystem(),
             aktueltBehov.fraIdentitetsnummer(),
             aktueltBehov.fraSaksnummer()
         )
     }
 
-    internal fun hentBehov(packet: JsonMessage, aktueltBehov: String) = KopierJournalpost(
+    internal fun hentBehov(
+        packet: JsonMessage,
+        aktueltBehov: String = packet.aktueltBehov()) = KopierJournalpost(
+        versjon = packet[aktueltBehov.versjon()].asText(),
         journalpostId = packet[aktueltBehov.journalpostId()].asText().somJournalpostId(),
-        fraIdentitetsnummer = when (packet[aktueltBehov.fraIdentitetsnummer()].isMissingOrNull()) {
-            true -> null
-            false -> packet[aktueltBehov.fraIdentitetsnummer()].asText().somIdentitetsnummer()
-        },
-        fraSaksnummer = when (packet[aktueltBehov.fraSaksnummer()].isMissingOrNull()) {
-            true -> null
-            false -> packet[aktueltBehov.fraSaksnummer()].asText().somSaksnummer()
-        },
+        fraIdentitetsnummer = packet[aktueltBehov.fraIdentitetsnummer()].asText().somIdentitetsnummer(),
+        fraSaksnummer = packet[aktueltBehov.fraSaksnummer()].asText().somSaksnummer(),
         tilIdentitetsnummer = packet[aktueltBehov.tilIdentitetsnummer()].asText().somIdentitetsnummer(),
         tilSaksnummer = packet[aktueltBehov.tilSaksnummer()].asText().somSaksnummer(),
         fagsystem = Fagsystem.valueOf(packet[aktueltBehov.fagsystem()].asText())
     )
 
-    internal fun leggTilLøsning(packet: JsonMessage, aktueltBehov: String, journalpostId: JournalpostId) {
+    internal fun leggTilLøsning(
+        packet: JsonMessage,
+        aktueltBehov: String,
+        journalpostId: JournalpostId) {
         packet.leggTilLøsning(
             behov = aktueltBehov,
             løsning = mapOf(
@@ -50,20 +64,26 @@ internal object KopierJournalpostMelding {
         )
     }
 
-    internal data class KopierJournalpost(
-        internal val journalpostId: JournalpostId,
-        internal val fraIdentitetsnummer: Identitetsnummer?,
-        internal val fraSaksnummer: Saksnummer?,
-        internal val tilIdentitetsnummer: Identitetsnummer,
-        internal val tilSaksnummer: Saksnummer,
-        internal val fagsystem: Fagsystem) {
-        internal val inneholderFraInformasjon = fraIdentitetsnummer != null && fraSaksnummer != null
+    internal fun leggTilBehovForFerdigstilling(packet: JsonMessage, aktueltBehov: String, kopierJournalpost: KopierJournalpost) {
+        packet.leggTilBehov(aktueltBehov,
+            Behov(navn = ferdigstillJornalføringBehov, input = mapOf(
+                "versjon" to "1.0.0",
+                "identitetsnummer" to "${kopierJournalpost.fraIdentitetsnummer}",
+                "saksnummer" to "${kopierJournalpost.fraSaksnummer}",
+                "fagsystem" to kopierJournalpost.fagsystem.name,
+                "journalpostIder" to listOf("${kopierJournalpost.journalpostId}")
+            ))
+        )
     }
 
+    internal const val behovNavn = "KopierJournalpost"
+    private const val ferdigstillJornalføringBehov = "${FerdigstillJournalføringMelding.behovNavn}@kopierJournalpost"
     private fun String.fraIdentitetsnummer() = "@behov.$this.fra.identitetsnummer"
     private fun String.fraSaksnummer() = "@behov.$this.fra.saksnummer"
     private fun String.tilIdentitetsnummer() = "@behov.$this.til.identitetsnummer"
     private fun String.tilSaksnummer() = "@behov.$this.til.saksnummer"
     private fun String.journalpostId() = "@behov.$this.journalpostId"
     private fun String.fagsystem() = "@behov.$this.fagsystem"
+    private fun String.versjon() = "@behov.$this.versjon"
+
 }

--- a/src/main/kotlin/no/nav/omsorgspenger/kopierjournalpost/KopierJournalpostMelding.kt
+++ b/src/main/kotlin/no/nav/omsorgspenger/kopierjournalpost/KopierJournalpostMelding.kt
@@ -1,0 +1,69 @@
+package no.nav.omsorgspenger.kopierjournalpost
+
+import no.nav.helse.rapids_rivers.JsonMessage
+import no.nav.helse.rapids_rivers.isMissingOrNull
+import no.nav.k9.rapid.river.leggTilLøsning
+import no.nav.omsorgspenger.Fagsystem
+import no.nav.omsorgspenger.Identitetsnummer
+import no.nav.omsorgspenger.Identitetsnummer.Companion.somIdentitetsnummer
+import no.nav.omsorgspenger.JournalpostId
+import no.nav.omsorgspenger.JournalpostId.Companion.somJournalpostId
+import no.nav.omsorgspenger.Saksnummer
+import no.nav.omsorgspenger.Saksnummer.Companion.somSaksnummer
+
+internal object KopierJournalpostMelding {
+
+    internal fun validateBehov(packet: JsonMessage, aktueltBehov: String) {
+        packet.requireKey(
+            aktueltBehov.tilIdentitetsnummer(),
+            aktueltBehov.tilSaksnummer(),
+            aktueltBehov.journalpostId(),
+            aktueltBehov.fagsystem()
+        )
+        packet.interestedIn(
+            aktueltBehov.fraIdentitetsnummer(),
+            aktueltBehov.fraSaksnummer()
+        )
+    }
+
+    internal fun hentBehov(packet: JsonMessage, aktueltBehov: String) = KopierJournalpost(
+        journalpostId = packet[aktueltBehov.journalpostId()].asText().somJournalpostId(),
+        fraIdentitetsnummer = when (packet[aktueltBehov.fraIdentitetsnummer()].isMissingOrNull()) {
+            true -> null
+            false -> packet[aktueltBehov.fraIdentitetsnummer()].asText().somIdentitetsnummer()
+        },
+        fraSaksnummer = when (packet[aktueltBehov.fraSaksnummer()].isMissingOrNull()) {
+            true -> null
+            false -> packet[aktueltBehov.fraSaksnummer()].asText().somSaksnummer()
+        },
+        tilIdentitetsnummer = packet[aktueltBehov.tilIdentitetsnummer()].asText().somIdentitetsnummer(),
+        tilSaksnummer = packet[aktueltBehov.tilSaksnummer()].asText().somSaksnummer(),
+        fagsystem = Fagsystem.valueOf(packet[aktueltBehov.fagsystem()].asText())
+    )
+
+    internal fun leggTilLøsning(packet: JsonMessage, aktueltBehov: String, journalpostId: JournalpostId) {
+        packet.leggTilLøsning(
+            behov = aktueltBehov,
+            løsning = mapOf(
+                "journalpostId" to "$journalpostId"
+            )
+        )
+    }
+
+    internal data class KopierJournalpost(
+        internal val journalpostId: JournalpostId,
+        internal val fraIdentitetsnummer: Identitetsnummer?,
+        internal val fraSaksnummer: Saksnummer?,
+        internal val tilIdentitetsnummer: Identitetsnummer,
+        internal val tilSaksnummer: Saksnummer,
+        internal val fagsystem: Fagsystem) {
+        internal val inneholderFraInformasjon = fraIdentitetsnummer != null && fraSaksnummer != null
+    }
+
+    private fun String.fraIdentitetsnummer() = "@behov.$this.fra.identitetsnummer"
+    private fun String.fraSaksnummer() = "@behov.$this.fra.saksnummer"
+    private fun String.tilIdentitetsnummer() = "@behov.$this.til.identitetsnummer"
+    private fun String.tilSaksnummer() = "@behov.$this.til.saksnummer"
+    private fun String.journalpostId() = "@behov.$this.journalpostId"
+    private fun String.fagsystem() = "@behov.$this.fagsystem"
+}

--- a/src/main/kotlin/no/nav/omsorgspenger/kopierjournalpost/KopierJournalpostRiver.kt
+++ b/src/main/kotlin/no/nav/omsorgspenger/kopierjournalpost/KopierJournalpostRiver.kt
@@ -1,0 +1,92 @@
+package no.nav.omsorgspenger.kopierjournalpost
+
+import kotlinx.coroutines.runBlocking
+import no.nav.helse.rapids_rivers.JsonMessage
+import no.nav.helse.rapids_rivers.RapidsConnection
+import no.nav.k9.rapid.river.BehovssekvensPacketListener
+import no.nav.k9.rapid.river.aktueltBehov
+import no.nav.omsorgspenger.CorrelationId.Companion.correlationId
+import no.nav.omsorgspenger.ferdigstilljournalforing.FerdigstillJournalføringMediator
+import no.nav.omsorgspenger.joark.DokarkivproxyClient
+import no.nav.omsorgspenger.joark.JoarkTyper
+import no.nav.omsorgspenger.joark.SafGateway
+import no.nav.omsorgspenger.joark.SafGateway.Companion.førsteJournalpostIdSomHarOriginalJournalpostId
+import org.slf4j.LoggerFactory
+import java.time.ZonedDateTime
+
+internal class KopierJournalpostRiver(
+    rapidsConnection: RapidsConnection,
+    private val ferdigstillJournalføringMediator: FerdigstillJournalføringMediator,
+    private val dokarkivproxyClient: DokarkivproxyClient,
+    private val safGateway: SafGateway,
+) : BehovssekvensPacketListener(
+    logger = LoggerFactory.getLogger(KopierJournalpostRiver::class.java)) {
+
+    override fun handlePacket(id: String, packet: JsonMessage): Boolean {
+        val aktueltBehov = packet.aktueltBehov()
+        val correlationId = packet.correlationId()
+        val kopierJournalpost = KopierJournalpostMelding.hentBehov(packet, aktueltBehov)
+
+        logger.info("Kopierer JournalpostId=[${kopierJournalpost.journalpostId}] for Fagsystem=[${kopierJournalpost.fagsystem.name}]")
+
+        // Håndterer om journalposten allerede er kopiert.
+        val alleredeKopiertJournalpostId = runBlocking { safGateway.hentOriginaleJournalpostIder(
+            fagsystem = kopierJournalpost.fagsystem,
+            saksnummer = kopierJournalpost.tilSaksnummer,
+            fraOgMed = ZonedDateTime.parse(packet["@opprettet"].asText()).minusWeeks(1).toLocalDate(),
+            correlationId = correlationId
+        )}.førsteJournalpostIdSomHarOriginalJournalpostId(kopierJournalpost.journalpostId)
+
+        if (alleredeKopiertJournalpostId != null) {
+            logger.info("Journalpost allerede kopiert. JournalpostId=[$alleredeKopiertJournalpostId]")
+            KopierJournalpostMelding.leggTilLøsning(
+                packet = packet,
+                aktueltBehov = aktueltBehov,
+                journalpostId = alleredeKopiertJournalpostId
+            )
+            return true
+        }
+
+        // Henter type og status på journalposten for å avgjøre hva vi gjør videre.
+        val typeOgStatus = runBlocking { safGateway.hentTypeOgStatus(
+            journalpostId = kopierJournalpost.journalpostId,
+            correlationId = packet.correlationId()
+        )}
+
+        // Om journalposten allerede er ferdigstilt kopierer vi den med en gang.
+        if (typeOgStatus.kanKopieresNå()) {
+            val nyJournalpostId = runBlocking { dokarkivproxyClient.knyttTilAnnenSak(
+                journalpostId = kopierJournalpost.journalpostId,
+                saksnummer = kopierJournalpost.tilSaksnummer,
+                fagsystem = kopierJournalpost.fagsystem,
+                identitetsnummer = kopierJournalpost.tilIdentitetsnummer,
+                correlationId = correlationId
+            )}
+
+            logger.info("Journalpost kopiert. JournalpostId=[$nyJournalpostId]")
+            KopierJournalpostMelding.leggTilLøsning(
+                packet = packet,
+                aktueltBehov = aktueltBehov,
+                journalpostId = nyJournalpostId
+            )
+            return true
+        }
+
+        // Legger til behov for å ferdigstille
+        if (typeOgStatus.måFerdigstillesFørKopiering() && kopierJournalpost.inneholderFraInformasjon) {
+            logger.info("Journalpost må ferdigstilles før den kopieres. Legger til behov for ferdigstilling.")
+            // TODO: legg til
+            return true
+        }
+
+        throw IllegalStateException("Kan ikke kopiere Journalpost. JournalpostId=[${kopierJournalpost.journalpostId}], Type=[${typeOgStatus.first}], Status=[${typeOgStatus.second}], InneholderFraInformasjon=[${kopierJournalpost.inneholderFraInformasjon}]")
+    }
+
+    private companion object {
+        private fun Pair<JoarkTyper.JournalpostType, JoarkTyper.JournalpostStatus>.kanKopieresNå() =
+            (first.erNotat && second.erFerdigstilt) || (first.erInngående && second.erJournalført)
+
+        private fun Pair<JoarkTyper.JournalpostType, JoarkTyper.JournalpostStatus>.måFerdigstillesFørKopiering() =
+            first.erInngående && second.erMottatt
+    }
+}

--- a/src/main/kotlin/no/nav/omsorgspenger/kopierjournalpost/KopierJournalpostRiver.kt
+++ b/src/main/kotlin/no/nav/omsorgspenger/kopierjournalpost/KopierJournalpostRiver.kt
@@ -89,6 +89,10 @@ internal class KopierJournalpostRiver(
             return true
         }
 
+        check(typeOgStatus.kanKopieresEtterFerdigstilling()) {
+            "Journalpost kan ikke kopieres. Type=[${typeOgStatus.first}], Status=[${typeOgStatus.second}]"
+        }
+
         // Legger til behov for å ferdigstille
         logger.info("Journalpost må ferdigstilles før den kopieres. Legger til behov for ferdigstilling.")
         KopierJournalpostMelding.leggTilBehovForFerdigstilling(
@@ -102,5 +106,8 @@ internal class KopierJournalpostRiver(
     private companion object {
         private fun Pair<JoarkTyper.JournalpostType, JoarkTyper.JournalpostStatus>.kanKopieresNå() =
             (first.erNotat && second.erFerdigstilt) || (first.erInngående && second.erJournalført)
+
+        private fun Pair<JoarkTyper.JournalpostType, JoarkTyper.JournalpostStatus>.kanKopieresEtterFerdigstilling() =
+            !kanKopieresNå() && (first.erNotat || first.erInngående)
     }
 }

--- a/src/test/kotlin/no/nav/omsorgspenger/ferdigstilljournalforing/FerdigstillJournalføringForOmsorgspengerFeilhåndteringTest.kt
+++ b/src/test/kotlin/no/nav/omsorgspenger/ferdigstilljournalforing/FerdigstillJournalføringForOmsorgspengerFeilhåndteringTest.kt
@@ -22,7 +22,7 @@ import java.net.URI
 import java.time.ZonedDateTime
 import java.util.*
 
-internal class FerdigstillJournalføringFeilhåndteringTest {
+internal class FerdigstillJournalføringForOmsorgspengerFeilhåndteringTest {
 
     private val mockJoarkClient = mockk<DokarkivClient>()
 

--- a/src/test/kotlin/no/nav/omsorgspenger/ferdigstilljournalforing/FerdigstillJournalføringForOmsorgspengerTest.kt
+++ b/src/test/kotlin/no/nav/omsorgspenger/ferdigstilljournalforing/FerdigstillJournalføringForOmsorgspengerTest.kt
@@ -14,7 +14,7 @@ import org.junit.jupiter.api.extension.ExtendWith
 import java.time.ZonedDateTime
 
 @ExtendWith(ApplicationContextExtension::class)
-internal class FerdigstillJournalføringTest(
+internal class FerdigstillJournalføringForOmsorgspengerTest(
         private val applicationContext: ApplicationContext) {
 
     private val rapid = TestRapid().apply {

--- a/src/test/kotlin/no/nav/omsorgspenger/ferdigstilljournalforing/FerdigstillJournalføringRiverTest.kt
+++ b/src/test/kotlin/no/nav/omsorgspenger/ferdigstilljournalforing/FerdigstillJournalføringRiverTest.kt
@@ -27,7 +27,7 @@ import org.junit.jupiter.api.extension.ExtendWith
 import java.util.*
 
 @ExtendWith(ApplicationContextExtension::class)
-internal class FerdigstillJournalføringTest(
+internal class FerdigstillJournalføringRiverTest(
     private val applicationContextBuilder: ApplicationContext.Builder) {
 
     private val dokarkivClientMock = mockk<DokarkivClient>().also { mock ->

--- a/src/test/kotlin/no/nav/omsorgspenger/ferdigstilljournalforing/FerdigstillJournalføringTest.kt
+++ b/src/test/kotlin/no/nav/omsorgspenger/ferdigstilljournalforing/FerdigstillJournalføringTest.kt
@@ -1,0 +1,184 @@
+package no.nav.omsorgspenger.ferdigstilljournalforing
+
+import de.huxhorn.sulky.ulid.ULID
+import io.mockk.clearMocks
+import io.mockk.coEvery
+import io.mockk.mockk
+import no.nav.helse.rapids_rivers.testsupport.TestRapid
+import no.nav.k9.rapid.behov.Behov
+import no.nav.k9.rapid.behov.Behovssekvens
+import no.nav.k9.rapid.river.leggTilLøsning
+import no.nav.omsorgspenger.*
+import no.nav.omsorgspenger.Identitetsnummer.Companion.somIdentitetsnummer
+import no.nav.omsorgspenger.JournalpostId.Companion.somJournalpostId
+import no.nav.omsorgspenger.joark.DokarkivClient
+import no.nav.omsorgspenger.joark.FerdigstillJournalpost
+import no.nav.omsorgspenger.joark.JoarkTyper.JournalpostStatus.Companion.somJournalpostStatus
+import no.nav.omsorgspenger.joark.SafGateway
+import no.nav.omsorgspenger.testutils.ApplicationContextExtension
+import no.nav.omsorgspenger.testutils.rapid.TestRapidVerktøy.behov
+import no.nav.omsorgspenger.testutils.rapid.TestRapidVerktøy.løsninger
+import no.nav.omsorgspenger.testutils.rapid.TestRapidVerktøy.sisteMeldingErKlarForArkivering
+import no.nav.omsorgspenger.testutils.rapid.TestRapidVerktøy.sisteMeldingSomJsonMessage
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import java.util.*
+
+@ExtendWith(ApplicationContextExtension::class)
+internal class FerdigstillJournalføringTest(
+    private val applicationContextBuilder: ApplicationContext.Builder) {
+
+    private val dokarkivClientMock = mockk<DokarkivClient>().also { mock ->
+        coEvery { mock.oppdaterJournalpostForFerdigstilling(any(), any()) }.returns(Unit)
+        coEvery { mock.ferdigstillJournalposten(any(), any()) }.returns(Unit)
+    }
+
+    private val safGatewayMock = mockk<SafGateway>()
+
+    private val rapid = TestRapid().apply {
+        this.registerApplicationContext(applicationContextBuilder.also { builder ->
+            builder.dokarkivClient = dokarkivClientMock
+            builder.safGateway = safGatewayMock
+        }.build())
+    }
+
+    @BeforeEach
+    internal fun reset() {
+        rapid.reset()
+        clearMocks(safGatewayMock)
+    }
+
+    @Test
+    fun `ferdigstille journalposter som allerede er ferdigstilt`() {
+        val journalpost1 = "12345678".somJournalpostId()
+        val journalpost2 = "910111213".somJournalpostId()
+
+        coEvery { safGatewayMock.hentFerdigstillJournalpost(any(), journalpost1) }.returns(FerdigstillJournalpost(
+            journalpostId = journalpost1,
+            status = "FERDIGSTILT".somJournalpostStatus()
+        ))
+
+        coEvery { safGatewayMock.hentFerdigstillJournalpost(any(), journalpost2) }.returns(FerdigstillJournalpost(
+            journalpostId = journalpost2,
+            status = "JOURNALFOERT".somJournalpostStatus()
+        ))
+
+        val (_, behovsskevens) = nyBehovsSekvens(
+            journalpostIder = setOf(journalpost1, journalpost2)
+        )
+
+        rapid.sendTestMessage(behovsskevens)
+        assertEquals(setOf(FerdigstillJournalføring), rapid.behov())
+        rapid.sisteMeldingErKlarForArkivering()
+    }
+
+    @Test
+    fun `mangler avsendernavn på en journalpost`() {
+        val journalpost1 = "12345678".somJournalpostId()
+        val journalpost2 = "910111213".somJournalpostId()
+        val identitetsnummer = "22222222222".somIdentitetsnummer()
+
+        coEvery { safGatewayMock.hentFerdigstillJournalpost(any(), journalpost1) }.returns(FerdigstillJournalpost(
+            journalpostId = journalpost1,
+            status = "MOTTATT".somJournalpostStatus(),
+            avsendernavn = null
+        ))
+
+        coEvery { safGatewayMock.hentFerdigstillJournalpost(any(), journalpost2) }.returns(FerdigstillJournalpost(
+            journalpostId = journalpost2,
+            status = "MOTTATT".somJournalpostStatus(),
+            avsendernavn = "Ola Nordmann"
+        ))
+
+        val (_, behovsskevens) = nyBehovsSekvens(
+            identitetsnummer = identitetsnummer,
+            journalpostIder = setOf(journalpost1, journalpost2)
+        )
+
+        rapid.sendTestMessage(behovsskevens)
+        assertEquals(setOf(HentNavn, FerdigstillJournalføring), rapid.behov())
+        assertEquals(emptySet<String>(), rapid.løsninger())
+
+        rapid.mockHentNavn(
+            identitetsnummer = identitetsnummer,
+            navn = "Kjell Nordmann"
+        )
+
+        assertEquals(setOf(HentNavn, FerdigstillJournalføring), rapid.løsninger())
+        rapid.sisteMeldingErKlarForArkivering()
+    }
+
+    @Test
+    fun `har avsendernavn på journalpost som skal ferdigstilles`() {
+        val journalpost1 = "12345678".somJournalpostId()
+        val journalpost2 = "910111213".somJournalpostId()
+        val behovNavn = "$FerdigstillJournalføring@testCase"
+
+        coEvery { safGatewayMock.hentFerdigstillJournalpost(any(), journalpost1) }.returns(FerdigstillJournalpost(
+            journalpostId = journalpost1,
+            status = "JOURNALFORT".somJournalpostStatus(),
+            avsendernavn = "Kari Nordmann"
+        ))
+
+        coEvery { safGatewayMock.hentFerdigstillJournalpost(any(), journalpost2) }.returns(FerdigstillJournalpost(
+            journalpostId = journalpost2,
+            status = "MOTTATT".somJournalpostStatus(),
+            avsendernavn = "Ola Nordmann"
+        ))
+
+        val (_, behovsskevens) = nyBehovsSekvens(
+            behov = behovNavn,
+            journalpostIder = setOf(journalpost1, journalpost2)
+        )
+
+        rapid.sendTestMessage(behovsskevens)
+        assertEquals(setOf(behovNavn), rapid.behov())
+
+        rapid.sisteMeldingErKlarForArkivering()
+    }
+
+    private companion object {
+        private const val HentNavn = "HentPersonopplysninger@ferdigstillJournalføring"
+        private const val FerdigstillJournalføring = "FerdigstillJournalføring"
+
+        private fun TestRapid.mockHentNavn(identitetsnummer: Identitetsnummer, navn: String) {
+            sendTestMessage(sisteMeldingSomJsonMessage().leggTilLøsning(
+                behov = HentNavn, løsning = mapOf(
+                    "personopplysninger" to mapOf(
+                        "$identitetsnummer" to mapOf(
+                            "navn" to mapOf(
+                                "sammensatt" to navn
+                            )
+                        )
+                    )
+                )
+            ).toJson())
+        }
+
+        private fun nyBehovsSekvens(
+            behov: String = FerdigstillJournalføring,
+            id: String = ULID().nextULID(),
+            identitetsnummer: Identitetsnummer = "11111111111".somIdentitetsnummer(),
+            journalpostIder: Set<JournalpostId>,
+            correlationId: String = UUID.randomUUID().toString(),
+            fagsystem: Fagsystem = Fagsystem.K9
+        ) = Behovssekvens(
+            id = id,
+            correlationId = correlationId,
+            behov = arrayOf(
+                Behov(
+                    navn = behov,
+                    input = mapOf(
+                        "versjon" to "1.0.0",
+                        "identitetsnummer" to "$identitetsnummer",
+                        "journalpostIder" to journalpostIder.map { "$it" },
+                        "saksnummer" to "a1b2c3",
+                        "fagsystem" to fagsystem.name
+                    )
+                )
+            )
+        ).keyValue
+    }
+}

--- a/src/test/kotlin/no/nav/omsorgspenger/joark/FerdigstillJournalpostTest.kt
+++ b/src/test/kotlin/no/nav/omsorgspenger/joark/FerdigstillJournalpostTest.kt
@@ -1,0 +1,222 @@
+package no.nav.omsorgspenger.joark
+
+import no.nav.omsorgspenger.Fagsystem
+import no.nav.omsorgspenger.Identitetsnummer.Companion.somIdentitetsnummer
+import no.nav.omsorgspenger.JournalpostId.Companion.somJournalpostId
+import no.nav.omsorgspenger.Saksnummer.Companion.somSaksnummer
+import no.nav.omsorgspenger.joark.JoarkTyper.JournalpostStatus.Companion.somJournalpostStatus
+import org.intellij.lang.annotations.Language
+import org.json.JSONObject
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import org.skyscreamer.jsonassert.JSONAssert
+
+internal class FerdigstillJournalpostTest {
+
+    @Test
+    fun `håndterer avsendernavn`() {
+        val ferdigstillJournalpost = FerdigstillJournalpost(
+            journalpostId = "11111111".somJournalpostId(),
+            status = "MOTATTT".somJournalpostStatus(),
+            avsendernavn = null
+        )
+
+        val bruker = FerdigstillJournalpost.Bruker(
+            identitetsnummer = "11111111111".somIdentitetsnummer(),
+            sak = Fagsystem.K9 to "ABC123".somSaksnummer(),
+            navn = null
+        )
+
+        assertFalse(ferdigstillJournalpost.kanFerdigstilles)
+
+        assertFalse(ferdigstillJournalpost.copy(bruker = bruker).kanFerdigstilles)
+
+        assertTrue(ferdigstillJournalpost.copy(bruker = bruker, avsendernavn = "Ola Nordmann").also {
+            it.assertAvsendernavnTilDokarkiv(null)
+        }.kanFerdigstilles)
+
+        assertTrue(ferdigstillJournalpost.copy(bruker = bruker.copy(navn = "Kari Nordmann"), avsendernavn = null).also {
+            it.assertAvsendernavnTilDokarkiv("Kari Nordmann")
+        }.kanFerdigstilles)
+
+        ferdigstillJournalpost.copy(bruker = bruker.copy(navn = "Kari Nordmann"), avsendernavn = "Ola Nordmann").also {
+            it.assertAvsendernavnTilDokarkiv(null)
+        }
+    }
+
+    @Test
+    fun `håndterer manglende tittel på hovedokument`() {
+        val ferdigstillJournalpost = FerdigstillJournalpost(
+            journalpostId = "1111111".somJournalpostId(),
+            status = "MOTTATT".somJournalpostStatus(),
+            avsendernavn = "Ola Nordmann",
+            tittel = null,
+            bruker = FerdigstillJournalpost.Bruker(
+                identitetsnummer = "11111111111".somIdentitetsnummer(),
+                sak = Fagsystem.K9 to "ABC123".somSaksnummer(),
+                navn = null
+            ),
+            dokumenter = setOf(FerdigstillJournalpost.Dokument(
+                dokumentId = "1",
+                tittel = "En tittel"
+            ))
+        )
+
+        @Language("JSON")
+        val forventet = """
+        {
+            "tema": "OMS",
+            "bruker": {
+                "idType": "FNR",
+                "id": "11111111111"
+            },
+            "sak": {
+                "fagsaksystem": "K9",
+                "sakstype": "FAGSAK",
+                "fagsakId": "ABC123"
+            },
+            "tittel": "Mangler tittel"
+        }
+        """.trimIndent()
+
+        JSONAssert.assertEquals(forventet, ferdigstillJournalpost.oppdaterPayload(), true)
+    }
+
+    @Test
+    fun `håndterer manglende tittel på dokumenter`() {
+        val ferdigstillJournalpost = FerdigstillJournalpost(
+            journalpostId = "1111111".somJournalpostId(),
+            status = "MOTTATT".somJournalpostStatus(),
+            avsendernavn = "Ola Nordmann",
+            tittel = "Har tittel",
+            bruker = FerdigstillJournalpost.Bruker(
+                identitetsnummer = "11111111111".somIdentitetsnummer(),
+                sak = Fagsystem.K9 to "ABC123".somSaksnummer(),
+                navn = null
+            ),
+            dokumenter = setOf(
+                FerdigstillJournalpost.Dokument(dokumentId = "1", tittel = null),
+                FerdigstillJournalpost.Dokument(dokumentId = "2", tittel = "Tittel 2"),
+                FerdigstillJournalpost.Dokument(dokumentId = "3", tittel = " ")
+            )
+        )
+
+        @Language("JSON")
+        val forventet = """
+        {
+            "tema": "OMS",
+            "bruker": {
+                "idType": "FNR",
+                "id": "11111111111"
+            },
+            "sak": {
+                "fagsaksystem": "K9",
+                "sakstype": "FAGSAK",
+                "fagsakId": "ABC123"
+            },
+            "dokumenter": {
+              "1": {
+                "tittel": "Mangler tittel"
+              },
+              "3": {
+                "tittel": "Mangler tittel"
+              }
+            }
+        }
+        """.trimIndent()
+
+
+        println(ferdigstillJournalpost.oppdaterPayload())
+
+        JSONAssert.assertEquals(forventet, ferdigstillJournalpost.oppdaterPayload(), true)
+    }
+
+    @Test
+    fun `håndterer ingen mangler`() {
+        val ferdigstillJournalpost = FerdigstillJournalpost(
+            journalpostId = "1111111".somJournalpostId(),
+            status = "MOTTATT".somJournalpostStatus(),
+            avsendernavn = "Ola Nordmann",
+            tittel = "Hovedtittel",
+            bruker = FerdigstillJournalpost.Bruker(
+                identitetsnummer = "11111111111".somIdentitetsnummer(),
+                sak = Fagsystem.K9 to "ABC123".somSaksnummer(),
+                navn = null
+            ),
+            dokumenter = setOf(FerdigstillJournalpost.Dokument(
+                dokumentId = "1",
+                tittel = "En tittel"
+            ))
+        )
+
+        @Language("JSON")
+        val forventet = """
+        {
+            "tema": "OMS",
+            "bruker": {
+                "idType": "FNR",
+                "id": "11111111111"
+            },
+            "sak": {
+                "fagsaksystem": "K9",
+                "sakstype": "FAGSAK",
+                "fagsakId": "ABC123"
+            }
+        }
+        """.trimIndent()
+
+        JSONAssert.assertEquals(forventet, ferdigstillJournalpost.oppdaterPayload(), true)
+    }
+
+    @Test
+    fun `håndterer brukers navn som avsendernavn`() {
+        val ferdigstillJournalpost = FerdigstillJournalpost(
+            journalpostId = "1111111".somJournalpostId(),
+            status = "MOTTATT".somJournalpostStatus(),
+            avsendernavn = null,
+            tittel = "Hovedtittel",
+            bruker = FerdigstillJournalpost.Bruker(
+                identitetsnummer = "11111111111".somIdentitetsnummer(),
+                sak = Fagsystem.K9 to "ABC123".somSaksnummer(),
+                navn = "Kari Nordmann"
+            ),
+            dokumenter = setOf(FerdigstillJournalpost.Dokument(
+                dokumentId = "1",
+                tittel = "En tittel"
+            ))
+        )
+
+        @Language("JSON")
+        val forventet = """
+        {
+            "tema": "OMS",
+            "bruker": {
+                "idType": "FNR",
+                "id": "11111111111"
+            },
+            "sak": {
+                "fagsaksystem": "K9",
+                "sakstype": "FAGSAK",
+                "fagsakId": "ABC123"
+            },
+            "avsenderMottaker": {
+              "navn": "Kari Nordmann"
+            }
+        }
+        """.trimIndent()
+
+        JSONAssert.assertEquals(forventet, ferdigstillJournalpost.oppdaterPayload(), true)
+    }
+
+    private companion object {
+        private fun FerdigstillJournalpost.assertAvsendernavnTilDokarkiv(forventet: String?) {
+            val json = JSONObject(oppdaterPayload())
+            if (forventet == null) {
+                assertFalse(json.has("avsenderMottaker"))
+            } else {
+                val avsenderMottaker = json.getJSONObject("avsenderMottaker")
+                assertEquals(forventet, avsenderMottaker.getString("navn"))
+            }
+        }
+    }
+}

--- a/src/test/kotlin/no/nav/omsorgspenger/joark/FerdigstillJournalpostTest.kt
+++ b/src/test/kotlin/no/nav/omsorgspenger/joark/FerdigstillJournalpostTest.kt
@@ -114,14 +114,13 @@ internal class FerdigstillJournalpostTest {
                 "sakstype": "FAGSAK",
                 "fagsakId": "ABC123"
             },
-            "dokumenter": {
-              "1": {
+            "dokumenter": [{
+                "dokumentInfoId": "1",
                 "tittel": "Mangler tittel"
-              },
-              "3": {
+            },{
+                "dokumentInfoId": "3",
                 "tittel": "Mangler tittel"
-              }
-            }
+            }]
         }
         """.trimIndent()
 

--- a/src/test/kotlin/no/nav/omsorgspenger/joark/SafGatewayTest.kt
+++ b/src/test/kotlin/no/nav/omsorgspenger/joark/SafGatewayTest.kt
@@ -6,10 +6,15 @@ import no.nav.omsorgspenger.joark.SafGateway.Companion.førsteJournalpostIdSomHa
 import no.nav.omsorgspenger.joark.SafGateway.Companion.hentOriginalJournalpostIderQuery
 import no.nav.omsorgspenger.joark.SafGateway.Companion.mapOriginaleJournalpostIderResponse
 import no.nav.omsorgspenger.Saksnummer.Companion.somSaksnummer
+import no.nav.omsorgspenger.joark.JoarkTyper.JournalpostStatus.Companion.somJournalpostStatus
+import no.nav.omsorgspenger.joark.JoarkTyper.JournalpostType.Companion.somJournalpostType
+import no.nav.omsorgspenger.joark.SafGateway.Companion.hentFerdigstillJournalpostQuery
+import no.nav.omsorgspenger.joark.SafGateway.Companion.hentTypeOgStatusQuery
+import no.nav.omsorgspenger.joark.SafGateway.Companion.mapFerdigstillJournalpost
+import no.nav.omsorgspenger.joark.SafGateway.Companion.mapTypeOgStatus
 import no.nav.omsorgspenger.joark.SafGateway.Companion.safData
 import org.intellij.lang.annotations.Language
-import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
 
@@ -26,6 +31,109 @@ internal class SafGatewayTest {
         )
 
         assertEquals(forventet, faktisk)
+    }
+
+    @Test
+    fun `request for hente type og status`() {
+        val journalpostId = "123123123".somJournalpostId()
+        val forventet = """{"query":"query {journalpost(journalpostId:\"123123123\"){journalposttype,journalstatus}}"}"""
+
+        val faktisk = hentTypeOgStatusQuery(journalpostId)
+        assertEquals(forventet, faktisk)
+    }
+
+    @Test
+    fun `map response på hente type og status`() {
+        @Language("JSON")
+        val response = """
+        {
+          "data": {
+            "journalpost": {
+              "journalposttype": "I",
+              "journalstatus": "JOURNALFOERT"
+            }
+          }
+        }
+        """.trimIndent()
+
+        val forventet = "I".somJournalpostType() to "JOURNALFOERT".somJournalpostStatus()
+        val faktisk = response.safData().mapTypeOgStatus()
+        assertEquals(forventet, faktisk)
+        assertTrue(forventet.first.erInngående)
+        assertTrue(forventet.second.erJournalført)
+    }
+
+    @Test
+    fun `request for hente ferdigstill journalpost`() {
+        val journalpostId = "123123123".somJournalpostId()
+        val forventet = """{"query":"query {journalpost(journalpostId:\"123123123\"){journalstatus,tittel,avsenderMottaker{navn},dokumenter{dokumentInfoId,tittel}}}"}"""
+
+        val faktisk = hentFerdigstillJournalpostQuery(journalpostId)
+        assertEquals(forventet, faktisk)
+    }
+
+    @Test
+    fun `map response på hente ferdigstill journalpost`() {
+        val journalpostId = "123123123".somJournalpostId()
+        val dokument = FerdigstillJournalpost.Dokument(
+            dokumentId = "55555555",
+            tittel = null
+        )
+
+        var forventet = FerdigstillJournalpost(
+            journalpostId = journalpostId,
+            status = "FERDIGSTILT".somJournalpostStatus(),
+            avsendernavn = null,
+            tittel = null,
+            dokumenter = setOf(dokument)
+        )
+
+        assertEquals(forventet, hentFerdigstillJournalpostResponse(
+            avsendernavn = null,
+            tittel = null,
+            dokumentTittel = null
+        ).safData().mapFerdigstillJournalpost(journalpostId))
+
+        forventet = forventet.copy(
+            tittel = "En tittel satt",
+            avsendernavn = "Ola Nordmann",
+            dokumenter = setOf(dokument.copy(
+                tittel = "En annen tittel satt"
+            ))
+        )
+
+        assertEquals(forventet, hentFerdigstillJournalpostResponse(
+            avsendernavn = "Ola Nordmann",
+            tittel = "En tittel satt",
+            dokumentTittel = "En annen tittel satt"
+        ).safData().mapFerdigstillJournalpost(journalpostId))
+    }
+
+    private fun hentFerdigstillJournalpostResponse(
+        avsendernavn: String?,
+        tittel: String?,
+        dokumentTittel: String?) : String {
+        @Language("JSON")
+        val response = """
+        {
+          "data": {
+            "journalpost": {
+              "journalstatus": "FERDIGSTILT",
+              "tittel": ${tittel?.let { "\"$it\"" }},
+              "avsenderMottaker": {
+                "navn": ${avsendernavn?.let { "\"$it\"" }}
+              },
+              "dokumenter": [
+                {
+                  "dokumentInfoId": "55555555",
+                  "tittel": ${dokumentTittel?.let { "\"$it\"" }}
+                }
+              ]
+            }
+          }
+        }
+        """.trimIndent()
+        return response
     }
 
     @Test

--- a/src/test/kotlin/no/nav/omsorgspenger/joark/SafGatewayTest.kt
+++ b/src/test/kotlin/no/nav/omsorgspenger/joark/SafGatewayTest.kt
@@ -6,6 +6,7 @@ import no.nav.omsorgspenger.joark.SafGateway.Companion.førsteJournalpostIdSomHa
 import no.nav.omsorgspenger.joark.SafGateway.Companion.hentOriginalJournalpostIderQuery
 import no.nav.omsorgspenger.joark.SafGateway.Companion.mapOriginaleJournalpostIderResponse
 import no.nav.omsorgspenger.Saksnummer.Companion.somSaksnummer
+import no.nav.omsorgspenger.joark.SafGateway.Companion.safData
 import org.intellij.lang.annotations.Language
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
@@ -66,7 +67,7 @@ internal class SafGatewayTest {
             "99999999999".somJournalpostId() to emptySet()
         )
 
-        val faktisk = response.mapOriginaleJournalpostIderResponse()
+        val faktisk = response.safData().mapOriginaleJournalpostIderResponse()
 
         assertEquals(forventet, faktisk)
     }

--- a/src/test/kotlin/no/nav/omsorgspenger/journalforjson/JournalførJsonRiverTest.kt
+++ b/src/test/kotlin/no/nav/omsorgspenger/journalforjson/JournalførJsonRiverTest.kt
@@ -15,7 +15,7 @@ import org.junit.jupiter.api.extension.ExtendWith
 import java.util.*
 
 @ExtendWith(ApplicationContextExtension::class)
-internal class JournalførJsonTest(
+internal class JournalførJsonRiverTest(
     private val applicationContext: ApplicationContext) {
 
     private val rapid = TestRapid().apply {

--- a/src/test/kotlin/no/nav/omsorgspenger/kopierjournalpost/KopierJournalpostForK9RiverTest.kt
+++ b/src/test/kotlin/no/nav/omsorgspenger/kopierjournalpost/KopierJournalpostForK9RiverTest.kt
@@ -14,7 +14,7 @@ import org.junit.jupiter.api.extension.ExtendWith
 import java.util.*
 
 @ExtendWith(ApplicationContextExtension::class)
-internal class KopierJournalpostForK9Test(
+internal class KopierJournalpostForK9RiverTest(
     private val applicationContext: ApplicationContext) {
 
     private val rapid = TestRapid().apply {

--- a/src/test/kotlin/no/nav/omsorgspenger/kopierjournalpost/KopierJournalpostRiverTest.kt
+++ b/src/test/kotlin/no/nav/omsorgspenger/kopierjournalpost/KopierJournalpostRiverTest.kt
@@ -1,0 +1,163 @@
+package no.nav.omsorgspenger.kopierjournalpost
+
+import de.huxhorn.sulky.ulid.ULID
+import io.mockk.clearMocks
+import io.mockk.coEvery
+import io.mockk.mockk
+import no.nav.helse.rapids_rivers.testsupport.TestRapid
+import no.nav.k9.rapid.behov.Behov
+import no.nav.k9.rapid.behov.Behovssekvens
+import no.nav.omsorgspenger.ApplicationContext
+import no.nav.omsorgspenger.Identitetsnummer
+import no.nav.omsorgspenger.Identitetsnummer.Companion.somIdentitetsnummer
+import no.nav.omsorgspenger.JournalpostId
+import no.nav.omsorgspenger.JournalpostId.Companion.somJournalpostId
+import no.nav.omsorgspenger.joark.DokarkivClient
+import no.nav.omsorgspenger.joark.FerdigstillJournalpost
+import no.nav.omsorgspenger.joark.JoarkTyper.JournalpostStatus.Companion.somJournalpostStatus
+import no.nav.omsorgspenger.joark.JoarkTyper.JournalpostType.Companion.somJournalpostType
+import no.nav.omsorgspenger.joark.SafGateway
+import no.nav.omsorgspenger.registerApplicationContext
+import no.nav.omsorgspenger.testutils.ApplicationContextExtension
+import no.nav.omsorgspenger.testutils.rapid.TestRapidVerktøy.behov
+import no.nav.omsorgspenger.testutils.rapid.TestRapidVerktøy.løsningPå
+import no.nav.omsorgspenger.testutils.rapid.TestRapidVerktøy.løsninger
+import no.nav.omsorgspenger.testutils.rapid.TestRapidVerktøy.printSisteMelding
+import no.nav.omsorgspenger.testutils.rapid.TestRapidVerktøy.sisteMelding
+import no.nav.omsorgspenger.testutils.rapid.TestRapidVerktøy.sisteMeldingErKlarForArkivering
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import java.util.*
+
+@ExtendWith(ApplicationContextExtension::class)
+internal class KopierJournalpostRiverTest(
+    private val applicationContextBuilder: ApplicationContext.Builder) {
+
+    private val safGatewayMock = mockk<SafGateway>()
+    private val dokarkivClientMock = mockk<DokarkivClient>().also { mock ->
+        coEvery { mock.oppdaterJournalpostForFerdigstilling(any(), any()) }.returns(Unit)
+        coEvery { mock.ferdigstillJournalposten(any(), any()) }.returns(Unit)
+    }
+
+    private val rapid = TestRapid().apply {
+        this.registerApplicationContext(applicationContextBuilder.also { builder ->
+            builder.safGateway = safGatewayMock
+            builder.dokarkivClient = dokarkivClientMock
+        }.build())
+    }
+
+    @BeforeEach
+    internal fun reset() {
+        rapid.reset()
+        clearMocks(safGatewayMock)
+    }
+
+    @Test
+    fun `Kopiere allerede kopiert journalpost`() {
+        val journalpostId = "123456789".somJournalpostId()
+        val (_, behovsskevens) = nyBehovsSekvens(
+            journalpostId = journalpostId
+        )
+
+        coEvery { safGatewayMock.hentOriginaleJournalpostIder(any(),any(),any(),any()) }.returns(mapOf(
+            "1011121314".somJournalpostId() to setOf(journalpostId)
+        ))
+
+        rapid.sendTestMessage(behovsskevens)
+        assertEquals("1011121314", rapid.løsningPå(KopierJournalpost).getString("journalpostId"))
+    }
+
+    @Test
+    fun `Kopiere allerede ferdigstilt journalpost`() {
+        val (_, behovsskevens) = nyBehovsSekvens()
+
+        coEvery { safGatewayMock.hentOriginaleJournalpostIder(any(),any(),any(),any()) }.returns(emptyMap())
+        coEvery { safGatewayMock.hentTypeOgStatus(any(), any()) }.returns("N".somJournalpostType() to "FERDIGSTILT".somJournalpostStatus())
+        rapid.sendTestMessage(behovsskevens)
+
+        assertEquals(setOf(KopierJournalpost), rapid.behov())
+        rapid.sisteMeldingErKlarForArkivering()
+        assertEquals("123412341234", rapid.løsningPå(KopierJournalpost).getString("journalpostId"))
+    }
+
+    @Test
+    fun `Kopiere fra og til samme person`() {
+        val identitetsnummer = "11111111119".somIdentitetsnummer()
+        val (_, behovsskevens) = nyBehovsSekvens(
+            fra = identitetsnummer,
+            til = identitetsnummer
+        )
+
+        coEvery { safGatewayMock.hentOriginaleJournalpostIder(any(),any(),any(),any()) }.returns(emptyMap())
+        coEvery { safGatewayMock.hentTypeOgStatus(any(), any()) }.returns("I".somJournalpostType() to "JOURNALFOERT".somJournalpostStatus())
+        rapid.sendTestMessage(behovsskevens)
+
+        assertEquals(setOf(KopierJournalpost), rapid.behov())
+        rapid.sisteMeldingErKlarForArkivering()
+        assertEquals("123412341234", rapid.løsningPå(KopierJournalpost).getString("journalpostId"))
+    }
+
+    @Test
+    fun `Kopiere journalpost som må ferdigstilles først`() {
+        val journalpostId = "147258369".somJournalpostId()
+        val behovNavn = "$KopierJournalpost@unitTest"
+        val (_, behovsskevens) = nyBehovsSekvens(behov = behovNavn, journalpostId = journalpostId)
+
+        coEvery { safGatewayMock.hentOriginaleJournalpostIder(any(),any(),any(),any()) }.returns(emptyMap())
+        coEvery { safGatewayMock.hentTypeOgStatus(journalpostId, any()) }.returns("I".somJournalpostType() to "MOTTATT".somJournalpostStatus())
+
+        rapid.sendTestMessage(behovsskevens)
+
+        assertEquals(setOf(FerdigstillJournalføringBehov, behovNavn), rapid.behov())
+        assertEquals(emptySet<String>(), rapid.løsninger())
+
+        // Sender melding for å bli løst av FerdigstillJournalføringRiver
+        coEvery { safGatewayMock.hentFerdigstillJournalpost(any(), journalpostId) }.returns(FerdigstillJournalpost(journalpostId = journalpostId, status = "MOTTATT".somJournalpostStatus(), avsendernavn = "Ola Nordmann"))
+        rapid.sendTestMessage(rapid.sisteMelding())
+        assertEquals(setOf(FerdigstillJournalføringBehov), rapid.løsninger())
+
+        // Sender melding for å bli løst på nytt nå som journalposten er ferdigstilt
+        coEvery { safGatewayMock.hentTypeOgStatus(journalpostId, any()) }.returns("I".somJournalpostType() to "JOURNALFOERT".somJournalpostStatus())
+        rapid.sendTestMessage(rapid.sisteMelding())
+        assertEquals(setOf(FerdigstillJournalføringBehov, behovNavn), rapid.løsninger())
+        rapid.sisteMeldingErKlarForArkivering()
+        assertEquals("123412341234", rapid.løsningPå(behovNavn).getString("journalpostId"))
+    }
+
+    private companion object {
+        private const val FerdigstillJournalføringBehov = "FerdigstillJournalføring@kopierJournalpost"
+        const val KopierJournalpost = "KopierJournalpost"
+
+        private fun nyBehovsSekvens(
+            behov: String = KopierJournalpost,
+            journalpostId: JournalpostId = "33333333333".somJournalpostId(),
+            fra: Identitetsnummer = "11111111111".somIdentitetsnummer(),
+            til: Identitetsnummer = "22222222222".somIdentitetsnummer(),
+            id: String = ULID().nextULID(),
+            correlationId: String = UUID.randomUUID().toString()
+        ) = Behovssekvens(
+            id = id,
+            correlationId = correlationId,
+            behov = arrayOf(
+                Behov(
+                    navn = behov,
+                    input = mapOf(
+                        "versjon" to "1.0.0",
+                        "journalpostId" to "$journalpostId",
+                        "fagsystem" to "K9",
+                        "fra" to mapOf(
+                            "identitetsnummer" to "$fra",
+                            "saksnummer" to "SAK${fra}"
+                        ),
+                        "til" to mapOf(
+                            "identitetsnummer" to "$til",
+                            "saksnummer" to "SAK${til}"
+                        )
+                    )
+                )
+            )
+        ).keyValue
+    }
+}

--- a/src/test/kotlin/no/nav/omsorgspenger/kopierjournalpost/KopierJournalpostTest.kt
+++ b/src/test/kotlin/no/nav/omsorgspenger/kopierjournalpost/KopierJournalpostTest.kt
@@ -1,0 +1,2 @@
+package no.nav.omsorgspenger.kopierjournalpost
+

--- a/src/test/kotlin/no/nav/omsorgspenger/kopierjournalpost/KopierJournalpostTest.kt
+++ b/src/test/kotlin/no/nav/omsorgspenger/kopierjournalpost/KopierJournalpostTest.kt
@@ -1,2 +1,0 @@
-package no.nav.omsorgspenger.kopierjournalpost
-

--- a/src/test/kotlin/no/nav/omsorgspenger/testutils/rapid/TestRapidVerktøy.kt
+++ b/src/test/kotlin/no/nav/omsorgspenger/testutils/rapid/TestRapidVerktøy.kt
@@ -1,0 +1,53 @@
+package no.nav.omsorgspenger.testutils.rapid
+
+import com.fasterxml.jackson.databind.node.TextNode
+import no.nav.helse.rapids_rivers.JsonMessage
+import no.nav.helse.rapids_rivers.MessageProblems
+import no.nav.helse.rapids_rivers.isMissingOrNull
+import no.nav.helse.rapids_rivers.testsupport.TestRapid
+import no.nav.k9.rapid.behov.Behovsformat
+import org.json.JSONObject
+import java.time.ZonedDateTime
+
+internal object TestRapidVerktøy {
+    internal fun TestRapid.sisteMelding() =
+        inspektør.message(inspektør.size - 1).toString()
+
+    internal fun String.somJsonMessage() =
+        JsonMessage(toString(), MessageProblems(this)).also { it.interestedIn("@løsninger") }
+
+    internal fun TestRapid.sisteMeldingSomJsonMessage() =
+        sisteMelding().somJsonMessage()
+
+    internal fun TestRapid.sisteMeldingSomJSONObject() =
+        JSONObject(sisteMelding())
+
+    internal fun TestRapid.printSisteMelding() =
+        println(sisteMeldingSomJSONObject().toString(1))
+
+    internal fun TestRapid.sisteMeldingHarLøsningPå(behov: String) {
+        val key = "@løsninger.$behov.løst"
+        val jsonMessage = sisteMeldingSomJsonMessage().also { it.interestedIn(key) }
+        val node = jsonMessage[key]
+        require(node is TextNode && ZonedDateTime.parse(node.textValue()) != null)
+    }
+
+    internal fun TestRapid.sisteMeldingManglerLøsningPå(behov: String) {
+        val key = "@løsninger.$behov.løst"
+        val jsonMessage = sisteMeldingSomJsonMessage().also { it.interestedIn(key) }
+        val node = jsonMessage[key]
+        require(node.isMissingOrNull())
+    }
+
+    internal fun TestRapid.behov() = sisteMeldingSomJSONObject().getJSONArray(Behovsformat.Behovsrekkefølge).map { "$it" }.toSet()
+    internal fun TestRapid.løsninger() = sisteMeldingSomJSONObject().let { when (it.has("@løsninger")) {
+        true -> it.getJSONObject("@løsninger").keySet()
+        false -> emptySet<String>()
+    }}
+
+    internal fun TestRapid.sisteMeldingErKlarForArkivering() {
+        require(behov() == løsninger()) {
+            "Behov=[${behov()}], Løsninger=[${løsninger()}]"
+        }
+    }
+}

--- a/src/test/kotlin/no/nav/omsorgspenger/testutils/rapid/TestRapidVerktøy.kt
+++ b/src/test/kotlin/no/nav/omsorgspenger/testutils/rapid/TestRapidVerktøy.kt
@@ -1,13 +1,10 @@
 package no.nav.omsorgspenger.testutils.rapid
 
-import com.fasterxml.jackson.databind.node.TextNode
 import no.nav.helse.rapids_rivers.JsonMessage
 import no.nav.helse.rapids_rivers.MessageProblems
-import no.nav.helse.rapids_rivers.isMissingOrNull
 import no.nav.helse.rapids_rivers.testsupport.TestRapid
 import no.nav.k9.rapid.behov.Behovsformat
 import org.json.JSONObject
-import java.time.ZonedDateTime
 
 internal object TestRapidVerktøy {
     internal fun TestRapid.sisteMelding() =
@@ -25,21 +22,10 @@ internal object TestRapidVerktøy {
     internal fun TestRapid.printSisteMelding() =
         println(sisteMeldingSomJSONObject().toString(1))
 
-    internal fun TestRapid.sisteMeldingHarLøsningPå(behov: String) {
-        val key = "@løsninger.$behov.løst"
-        val jsonMessage = sisteMeldingSomJsonMessage().also { it.interestedIn(key) }
-        val node = jsonMessage[key]
-        require(node is TextNode && ZonedDateTime.parse(node.textValue()) != null)
-    }
-
-    internal fun TestRapid.sisteMeldingManglerLøsningPå(behov: String) {
-        val key = "@løsninger.$behov.løst"
-        val jsonMessage = sisteMeldingSomJsonMessage().also { it.interestedIn(key) }
-        val node = jsonMessage[key]
-        require(node.isMissingOrNull())
-    }
+    internal fun TestRapid.løsningPå(behov: String) = sisteMeldingSomJSONObject().let { it.getJSONObject("@løsninger").getJSONObject(behov) }
 
     internal fun TestRapid.behov() = sisteMeldingSomJSONObject().getJSONArray(Behovsformat.Behovsrekkefølge).map { "$it" }.toSet()
+
     internal fun TestRapid.løsninger() = sisteMeldingSomJSONObject().let { when (it.has("@løsninger")) {
         true -> it.getJSONObject("@løsninger").keySet()
         false -> emptySet<String>()


### PR DESCRIPTION
- Nytt `FerdigstillJournalføring` -behov som løser manglende navn på en bedre måte, samt håndterer manglende titler. Trenger input om `fagsystem` i motsetning til de to gamle behovene som skal fjernes når dette blir tatt i bruk.

- Nytt `KopierJournalpost` -behov som løser manglende ferdigstilling med `FerdigstillJournalføring`-behov. Støtter kopiering av både Notat og Inngående journalposter. Trenger også input som `fagsystem`. 