### PR TITLE
Revert "Går direkt mot dokarkiv for knyttTilAnnensak"

### DIFF
--- a/nais/dev-gcp.json
+++ b/nais/dev-gcp.json
@@ -5,6 +5,7 @@
   ],
   "externalHosts": [
     "dokarkiv.dev-fss-pub.nais.io",
+    "omsorgspenger-proxy.dev-fss.nais.io",
     "oppgave-q1.dev-fss-pub.nais.io",
     "saf.dev-fss-pub.nais.io"
   ],
@@ -15,6 +16,8 @@
     "DOKARKIV_SCOPES": "api://dev-fss.teamdokumenthandtering.dokarkiv-q1/.default",
     "OPPGAVE_BASE_URL": "https://oppgave-q1.dev-fss-pub.nais.io",
     "OPPGAVE_SCOPES": "api://dev-fss.oppgavehandtering.oppgave-q1/.default",
+    "DOKARKIVPROXY_BASE_URL": "https://omsorgspenger-proxy.dev-fss-pub.nais.io/dokarkivproxy",
+    "DOKARKIVPROXY_SCOPES": "824525c6-74df-47fc-8892-444e5f8506de/.default",
     "SAF_BASE_URL": "https://saf.dev-fss-pub.nais.io",
     "SAF_SCOPES": "api://dev-fss.teamdokumenthandtering.saf-q1/.default"
   }

--- a/nais/prod-gcp.json
+++ b/nais/prod-gcp.json
@@ -5,6 +5,7 @@
   ],
   "externalHosts": [
     "dokarkiv.prod-fss-pub.nais.io",
+    "omsorgspenger-proxy.prod-fss-pub.nais.io",
     "oppgave.prod-fss-pub.nais.io",
     "saf.prod-fss-pub.nais.io"
   ],
@@ -15,6 +16,8 @@
     "DOKARKIV_SCOPES": "api://prod-fss.teamdokumenthandtering.dokarkiv/.default",
     "OPPGAVE_BASE_URL": "https://oppgave.prod-fss-pub.nais.io",
     "OPPGAVE_SCOPES": "api://prod-fss.oppgavehandtering.oppgave/.default",
+    "DOKARKIVPROXY_BASE_URL": "https://omsorgspenger-proxy.prod-fss-pub.nais.io/dokarkivproxy",
+    "DOKARKIVPROXY_SCOPES": "e816bb42-bf62-4be9-a1cc-a9be70fe4403/.default",
     "SAF_BASE_URL": "https://saf.prod-fss-pub.nais.io",
     "SAF_SCOPES": "api://prod-fss.teamdokumenthandtering.saf/.default"
   }

--- a/src/main/kotlin/no/nav/omsorgspenger/App.kt
+++ b/src/main/kotlin/no/nav/omsorgspenger/App.kt
@@ -40,7 +40,7 @@ internal fun RapidsConnection.registerApplicationContext(applicationContext: App
     )
     KopierJournalpostRiver(
         rapidsConnection = this,
-        dokarkivClient = applicationContext.dokarkivClient,
+        dokarkivproxyClient = applicationContext.dokarkivproxyClient,
         safGateway = applicationContext.safGateway
     )
 

--- a/src/main/kotlin/no/nav/omsorgspenger/ApplicationContext.kt
+++ b/src/main/kotlin/no/nav/omsorgspenger/ApplicationContext.kt
@@ -10,6 +10,7 @@ import no.nav.k9.rapid.river.RapidsStateListener
 import no.nav.k9.rapid.river.csvTilSet
 import no.nav.k9.rapid.river.hentRequiredEnv
 import no.nav.omsorgspenger.joark.DokarkivClient
+import no.nav.omsorgspenger.joark.DokarkivproxyClient
 import no.nav.omsorgspenger.joark.SafGateway
 import no.nav.omsorgspenger.oppgave.OppgaveClient
 import java.net.URI
@@ -17,6 +18,7 @@ import java.net.URI
 internal class ApplicationContext(
     internal val env: Environment,
     internal val dokarkivClient: DokarkivClient,
+    internal val dokarkivproxyClient: DokarkivproxyClient,
     internal val safGateway: SafGateway,
     internal val oppgaveClient: OppgaveClient,
     internal val healthChecks: Set<HealthCheck>
@@ -31,6 +33,7 @@ internal class ApplicationContext(
         internal var httpClient: HttpClient? = null,
         internal var accessTokenClient: AccessTokenClient? = null,
         internal var dokarkivClient: DokarkivClient? = null,
+        internal var dokarkivproxyClient: DokarkivproxyClient? = null,
         internal var safGateway: SafGateway? = null,
         internal var oppgaveClient: OppgaveClient? = null
     ) {
@@ -55,6 +58,11 @@ internal class ApplicationContext(
                 accessTokenClient = benyttetAccessTokenClient,
                 httpClient = benyttetHttpClient
             )
+            val benyttetDokarkivproxyClient = dokarkivproxyClient ?: DokarkivproxyClient(
+                accessTokenClient = benyttetAccessTokenClient,
+                baseUrl = URI(benyttetEnv.hentRequiredEnv("DOKARKIVPROXY_BASE_URL")),
+                scopes = benyttetEnv.hentRequiredEnv("DOKARKIVPROXY_SCOPES").csvTilSet()
+            )
             val benyttetSafGateway = safGateway ?: SafGateway(
                 accessTokenClient = benyttetAccessTokenClient,
                 baseUrl = URI(benyttetEnv.hentRequiredEnv("SAF_BASE_URL")),
@@ -67,9 +75,11 @@ internal class ApplicationContext(
                 healthChecks = setOf(
                     benyttetDokarkivClient,
                     benyttetOppgaveClient,
+                    benyttetDokarkivproxyClient,
                     benyttetSafGateway
                 ),
                 oppgaveClient = benyttetOppgaveClient,
+                dokarkivproxyClient = benyttetDokarkivproxyClient,
                 safGateway = benyttetSafGateway
             )
         }

--- a/src/main/kotlin/no/nav/omsorgspenger/joark/DokarkivClient.kt
+++ b/src/main/kotlin/no/nav/omsorgspenger/joark/DokarkivClient.kt
@@ -10,12 +10,8 @@ import no.nav.helse.dusseldorf.ktor.client.SimpleHttpClient.readTextOrThrow
 import no.nav.helse.dusseldorf.oauth2.client.AccessTokenClient
 import no.nav.omsorgspenger.AzureAwareClient
 import no.nav.omsorgspenger.CorrelationId
-import no.nav.omsorgspenger.Fagsystem
-import no.nav.omsorgspenger.Identitetsnummer
 import no.nav.omsorgspenger.JournalpostId
 import no.nav.omsorgspenger.JournalpostId.Companion.somJournalpostId
-import no.nav.omsorgspenger.Saksnummer
-import org.intellij.lang.annotations.Language
 import org.json.JSONObject
 import java.net.URI
 
@@ -31,9 +27,6 @@ internal class DokarkivClient(
 ) {
 
     private val opprettJournalpostUrl = "$baseUrl/rest/journalpostapi/v1/journalpost?forsoekFerdigstill=true"
-    private fun knyttTilAnnenSakUrl(journalpostId: JournalpostId) =
-        "$baseUrl/rest/journalpostapi/v1/journalpost/$journalpostId/knyttTilAnnenSak"
-
     private fun JournalpostId.oppdaterJournalpostUrl() = "$baseUrl/rest/journalpostapi/v1/journalpost/${this}"
     private fun JournalpostId.ferdigstillJournalpostUrl() =
         "$baseUrl/rest/journalpostapi/v1/journalpost/${this}/ferdigstill"
@@ -88,44 +81,6 @@ internal class DokarkivClient(
         check(httpStatus.isSuccess()) {
             "Feil ved ferdigstilling av journalpost. HttpStatus=[${httpStatus.value}, Response=[$responseBody], Url=[$url]"
         }
-    }
-
-    internal suspend fun knyttTilAnnenSak(
-        journalpostId: JournalpostId,
-        fagsystem: Fagsystem,
-        identitetsnummer: Identitetsnummer,
-        saksnummer: Saksnummer,
-        correlationId: CorrelationId
-    ): JournalpostId {
-        @Language("JSON")
-        val dto = """
-        {
-            "sakstype": "FAGSAK",
-            "fagsaksystem": "${fagsystem.name}",
-            "fagsakId": "$saksnummer",
-            "journalfoerendeEnhet": "9999",
-            "tema": "OMS",
-            "bruker": {
-                "idType": "FNR",
-                "id": "$identitetsnummer"
-            }
-        }
-        """.trimIndent()
-
-        val url = knyttTilAnnenSakUrl(journalpostId = journalpostId)
-        val (httpStatusCode, response) = url.httpPut { builder ->
-            builder.header("Nav-CallId", "$correlationId")
-            builder.header("Nav-Consumer-Id", "omsorgspenger-journalforing")
-            builder.accept(ContentType.Application.Json)
-            builder.header(HttpHeaders.Authorization, authorizationHeader())
-            builder.jsonBody(dto)
-        }.readTextOrThrow()
-
-        require(httpStatusCode.isSuccess()) {
-            "Feil fra Dokarkivproxy. URL=[$url], HttpStatusCode=[${httpStatusCode.value}], Response=[$response]"
-        }
-
-        return JSONObject(response).getString("nyJournalpostId").somJournalpostId()
     }
 
     private fun HttpRequestBuilder.defaultHeaders(correlationId: CorrelationId) {

--- a/src/main/kotlin/no/nav/omsorgspenger/joark/DokarkivproxyClient.kt
+++ b/src/main/kotlin/no/nav/omsorgspenger/joark/DokarkivproxyClient.kt
@@ -1,0 +1,71 @@
+package no.nav.omsorgspenger.joark
+
+import io.ktor.client.request.*
+import io.ktor.http.*
+import no.nav.helse.dusseldorf.ktor.client.SimpleHttpClient.httpPut
+import no.nav.helse.dusseldorf.ktor.client.SimpleHttpClient.jsonBody
+import no.nav.helse.dusseldorf.ktor.client.SimpleHttpClient.readTextOrThrow
+import no.nav.helse.dusseldorf.oauth2.client.AccessTokenClient
+import no.nav.omsorgspenger.*
+import no.nav.omsorgspenger.AzureAwareClient
+import no.nav.omsorgspenger.CorrelationId
+import no.nav.omsorgspenger.Identitetsnummer
+import no.nav.omsorgspenger.JournalpostId
+import no.nav.omsorgspenger.JournalpostId.Companion.somJournalpostId
+import no.nav.omsorgspenger.Saksnummer
+import org.intellij.lang.annotations.Language
+import org.json.JSONObject
+import java.net.URI
+
+internal class DokarkivproxyClient(
+    accessTokenClient: AccessTokenClient,
+    private val baseUrl: URI,
+    scopes: Set<String>
+) : AzureAwareClient(
+    navn = "DokarkivproxyClient",
+    accessTokenClient = accessTokenClient,
+    scopes = scopes,
+    pingUrl = URI("$baseUrl/isReady")
+) {
+
+    private fun knyttTilAnnenSakUrl(journalpostId: JournalpostId) =
+        "$baseUrl/rest/journalpostapi/v1/journalpost/$journalpostId/knyttTilAnnenSak"
+
+    internal suspend fun knyttTilAnnenSak(
+        journalpostId: JournalpostId,
+        fagsystem: Fagsystem,
+        identitetsnummer: Identitetsnummer,
+        saksnummer: Saksnummer,
+        correlationId: CorrelationId
+    ): JournalpostId {
+        @Language("JSON")
+        val dto = """
+        {
+            "sakstype": "FAGSAK",
+            "fagsaksystem": "${fagsystem.name}",
+            "fagsakId": "$saksnummer",
+            "journalfoerendeEnhet": "9999",
+            "tema": "OMS",
+            "bruker": {
+                "idType": "FNR",
+                "id": "$identitetsnummer"
+            }
+        }
+        """.trimIndent()
+
+        val url = knyttTilAnnenSakUrl(journalpostId = journalpostId)
+        val (httpStatusCode, response) = url.httpPut { builder ->
+            builder.header("Nav-CallId", "$correlationId")
+            builder.header("Nav-Consumer-Id", "omsorgspenger-journalforing")
+            builder.accept(ContentType.Application.Json)
+            builder.header(HttpHeaders.Authorization, authorizationHeader())
+            builder.jsonBody(dto)
+        }.readTextOrThrow()
+
+        require(httpStatusCode.isSuccess()) {
+            "Feil fra Dokarkivproxy. URL=[$url], HttpStatusCode=[${httpStatusCode.value}], Response=[$response]"
+        }
+
+        return JSONObject(response).getString("nyJournalpostId").somJournalpostId()
+    }
+}

--- a/src/main/kotlin/no/nav/omsorgspenger/joark/Journalpost.kt
+++ b/src/main/kotlin/no/nav/omsorgspenger/joark/Journalpost.kt
@@ -1,0 +1,12 @@
+package no.nav.omsorgspenger.joark
+
+import no.nav.omsorgspenger.Fagsystem
+
+internal data class Journalpost(
+    val journalpostId: String,
+    val identitetsnummer: String,
+    val saksnummer: String,
+    val navn: String? = null,
+    val fagsaksystem: Fagsystem
+)
+

--- a/src/main/kotlin/no/nav/omsorgspenger/kopierjournalpost/KopierJournalpostRiver.kt
+++ b/src/main/kotlin/no/nav/omsorgspenger/kopierjournalpost/KopierJournalpostRiver.kt
@@ -1,15 +1,17 @@
 package no.nav.omsorgspenger.kopierjournalpost
 
+import com.fasterxml.jackson.databind.node.TextNode
 import kotlinx.coroutines.runBlocking
 import no.nav.helse.rapids_rivers.JsonMessage
 import no.nav.helse.rapids_rivers.RapidsConnection
 import no.nav.helse.rapids_rivers.River
 import no.nav.helse.rapids_rivers.isMissingOrNull
+import no.nav.k9.rapid.behov.Behovsformat
 import no.nav.k9.rapid.river.BehovssekvensPacketListener
 import no.nav.k9.rapid.river.aktueltBehov
 import no.nav.k9.rapid.river.skalLøseBehov
 import no.nav.omsorgspenger.CorrelationId.Companion.correlationId
-import no.nav.omsorgspenger.joark.DokarkivClient
+import no.nav.omsorgspenger.joark.DokarkivproxyClient
 import no.nav.omsorgspenger.joark.JoarkTyper
 import no.nav.omsorgspenger.joark.SafGateway
 import no.nav.omsorgspenger.joark.SafGateway.Companion.førsteJournalpostIdSomHarOriginalJournalpostId
@@ -18,7 +20,7 @@ import java.time.ZonedDateTime
 
 internal class KopierJournalpostRiver(
     rapidsConnection: RapidsConnection,
-    private val dokarkivClient: DokarkivClient,
+    private val dokarkivproxyClient: DokarkivproxyClient,
     private val safGateway: SafGateway,
 ) : BehovssekvensPacketListener(
     logger = LoggerFactory.getLogger(KopierJournalpostRiver::class.java)) {
@@ -74,7 +76,7 @@ internal class KopierJournalpostRiver(
 
         // Om journalposten allerede er ferdigstilt kopierer vi den med en gang.
         if (typeOgStatus.kanKopieresNå()) {
-            val nyJournalpostId = runBlocking { dokarkivClient.knyttTilAnnenSak(
+            val nyJournalpostId = runBlocking { dokarkivproxyClient.knyttTilAnnenSak(
                 journalpostId = kopierJournalpost.journalpostId,
                 saksnummer = kopierJournalpost.tilSaksnummer,
                 fagsystem = kopierJournalpost.fagsystem,

--- a/src/test/kotlin/no/nav/omsorgspenger/kopierjournalpost/KopierJournalpostRiverTest.kt
+++ b/src/test/kotlin/no/nav/omsorgspenger/kopierjournalpost/KopierJournalpostRiverTest.kt
@@ -38,7 +38,6 @@ internal class KopierJournalpostRiverTest(
     private val dokarkivClientMock = mockk<DokarkivClient>().also { mock ->
         coEvery { mock.oppdaterJournalpostForFerdigstilling(any(), any()) }.returns(Unit)
         coEvery { mock.ferdigstillJournalpost(any(), any()) }.returns(Unit)
-        coEvery { mock.knyttTilAnnenSak(any(), any(), any(), any(), any()) }.returns("123412341234".somJournalpostId())
     }
 
     private val rapid = TestRapid().apply {

--- a/src/test/kotlin/no/nav/omsorgspenger/testutils/ApplicationContextExtension.kt
+++ b/src/test/kotlin/no/nav/omsorgspenger/testutils/ApplicationContextExtension.kt
@@ -20,6 +20,7 @@ internal class ApplicationContextExtension : ParameterResolver {
             .build()
             .stubDokarkiv()
             .stubOppgaveMock()
+            .stubDokarkivproxy()
             .stubSaf()
 
         private val applicationContextBuilder = ApplicationContext.Builder(
@@ -28,6 +29,8 @@ internal class ApplicationContextExtension : ParameterResolver {
                 "DOKARKIV_SCOPES" to "dokarkiv/.default",
                 "OPPGAVE_BASE_URL" to wireMockServer.oppgaveApiBaseUrl(),
                 "OPPGAVE_SCOPES" to "oppgave/.default",
+                "DOKARKIVPROXY_BASE_URL" to wireMockServer.dokarkivproxyBaseUrl(),
+                "DOKARKIVPROXY_SCOPES" to "dokarkivproxy/.default",
                 "SAF_BASE_URL" to wireMockServer.safBaseUrl(),
                 "SAF_SCOPES" to "saf/.default",
                 "AZURE_APP_CLIENT_ID" to "omsorgspenger-journalforing",

--- a/src/test/kotlin/no/nav/omsorgspenger/testutils/wiremock/DokarkivMock.kt
+++ b/src/test/kotlin/no/nav/omsorgspenger/testutils/wiremock/DokarkivMock.kt
@@ -15,10 +15,8 @@ private const val journalpostPath = "$basePath/rest/journalpostapi/v1/journalpos
 
 private fun oppdaterJournalpostMapping(
     callIdPattern: StringValuePattern = AnythingPattern()
-) = WireMock.put(
-    WireMock
-        .urlMatching(".*$journalpostPath.*")
-)
+) = WireMock.put(WireMock
+    .urlMatching(".*$journalpostPath.*"))
     .withHeader("Authorization", RegexPattern("^Bearer .+$"))
     .withHeader("Content-Type", equalTo("application/json"))
     .withHeader("Nav-Consumer-Id", equalTo("omsorgspenger-journalforing"))
@@ -31,24 +29,20 @@ private fun oppdaterJournalpostMapping(
 
 private fun opprettJournalpostMapping(
     callIdPattern: StringValuePattern = AnythingPattern()
-) = WireMock.post(
-    WireMock
-        .urlMatching(".*$journalpostPath.*")
-)
+) = WireMock.post(WireMock
+    .urlMatching(".*$journalpostPath.*"))
     .withQueryParam("forsoekFerdigstill", equalTo("true"))
     .withHeader("Authorization", RegexPattern("^Bearer .+$"))
     .withHeader("Content-Type", equalTo("application/json"))
     .withHeader("Nav-Consumer-Id", equalTo("omsorgspenger-journalforing"))
     .withHeader("Nav-Callid", callIdPattern)
     .withRequestBody(matchingJsonPath("$.sak.fagsaksystem", WireMock.matching("K9|OMSORGSPENGER")))
-// Tester formatet på denn JSON'en i NyJournalpostTest, sjekker derfor her bare en prop
+    // Tester formatet på denn JSON'en i NyJournalpostTest, sjekker derfor her bare en prop
 
 private fun ferdigstillJournalpostMapping(
     callIdPattern: StringValuePattern = AnythingPattern()
-) = WireMock.patch(
-    WireMock
-        .urlPathMatching(".*$journalpostPath.*")
-)
+) = WireMock.patch(WireMock
+    .urlPathMatching(".*$journalpostPath.*"))
     .withHeader("Authorization", RegexPattern("^Bearer .+$"))
     .withHeader("Content-Type", equalTo("application/json"))
     .withHeader("Nav-Consumer-Id", equalTo("omsorgspenger-journalforing"))
@@ -56,23 +50,21 @@ private fun ferdigstillJournalpostMapping(
     .withRequestBody(matchingJsonPath("$.journalfoerendeEnhet", containing("9999")))
 
 private fun WireMockServer.stubOppdaterJournalpostOk() = also {
-    stubFor(
-        oppdaterJournalpostMapping()
-            .willReturn(
-                WireMock.aResponse()
-                    .withStatus(200)
-            )
+    stubFor(oppdaterJournalpostMapping()
+        .willReturn(
+            WireMock.aResponse()
+                .withStatus(200)
+        )
     )
 }
 
 private fun WireMockServer.stubOppdaterJournalpostUventetFeil() = also {
-    stubFor(
-        oppdaterJournalpostMapping(callIdPattern = equalTo("400"))
-            .willReturn(
-                WireMock.aResponse()
-                    .withStatus(400)
-                    .withBody("Noe gikk helt galt")
-            )
+    stubFor(oppdaterJournalpostMapping(callIdPattern = equalTo("400"))
+        .willReturn(
+            WireMock.aResponse()
+                .withStatus(400)
+                .withBody("Noe gikk helt galt")
+        )
     )
 }
 
@@ -87,104 +79,71 @@ private fun WireMockServer.stubOppdaterJournalpostAlleredeFerdigstilt() = also {
         	"path": "/rest/journalpostapi/v1/journalpost/111111111"
         }
     """.trimIndent()
-    stubFor(
-        oppdaterJournalpostMapping(callIdPattern = equalTo("allerede-ferdigstilt"))
-            .willReturn(
-                WireMock.aResponse()
-                    .withStatus(400)
-                    .withBody(json)
-            )
+    stubFor(oppdaterJournalpostMapping(callIdPattern = equalTo("allerede-ferdigstilt"))
+        .willReturn(
+            WireMock.aResponse()
+                .withStatus(400)
+                .withBody(json)
+        )
     )
 }
 
 private fun WireMockServer.stubFerdigstillJournalpostOk() = also {
-    stubFor(
-        ferdigstillJournalpostMapping()
-            .willReturn(
-                WireMock.aResponse()
-                    .withStatus(200)
-            )
+    stubFor(ferdigstillJournalpostMapping()
+        .willReturn(
+            WireMock.aResponse()
+                .withStatus(200)
+        )
     )
 }
 
 private fun WireMockServer.stubFerdigstillJournalpostUventetFeil() = also {
-    stubFor(
-        ferdigstillJournalpostMapping(callIdPattern = equalTo("feil-ved-ferdigstilling"))
-            .willReturn(
-                WireMock.aResponse()
-                    .withStatus(400)
-            )
+    stubFor(ferdigstillJournalpostMapping(callIdPattern = equalTo("feil-ved-ferdigstilling"))
+        .willReturn(
+            WireMock.aResponse()
+                .withStatus(400)
+        )
     )
 }
 
 private fun WireMockServer.stubOpprettJournalpostOk() = also {
-    stubFor(
-        opprettJournalpostMapping().willReturn(
-            WireMock.aResponse()
-                .withStatus(201)
-                .withBody("""{"journalpostId":"12345678", "journalpostferdigstilt": true}""")
-        )
-    )
+    stubFor(opprettJournalpostMapping().willReturn(WireMock.aResponse()
+        .withStatus(201)
+        .withBody("""{"journalpostId":"12345678", "journalpostferdigstilt": true}""")
+    ))
 }
 
 private fun WireMockServer.stubOpprettJournalpostAlleredeOpprettet() = also {
-    stubFor(
-        opprettJournalpostMapping(callIdPattern = equalTo("allerede-opprettet")).willReturn(
-            WireMock.aResponse()
-                .withStatus(409)
-                .withBody("""{"journalpostId":"910111213", "journalpostferdigstilt": true}""")
-        )
-    )
+    stubFor(opprettJournalpostMapping(callIdPattern = equalTo("allerede-opprettet")).willReturn(WireMock.aResponse()
+        .withStatus(409)
+        .withBody("""{"journalpostId":"910111213", "journalpostferdigstilt": true}""")
+    ))
 }
 
 private fun WireMockServer.stubOpprettJournalpostIkkeFerdigstilt() = also {
-    stubFor(
-        opprettJournalpostMapping(callIdPattern = equalTo("ikke-ferdigstilt")).willReturn(
-            WireMock.aResponse()
-                .withStatus(201)
-                .withBody("""{"journalpostId":"1415161718", "journalpostferdigstilt": false}""")
-        )
-    )
+    stubFor(opprettJournalpostMapping(callIdPattern = equalTo("ikke-ferdigstilt")).willReturn(WireMock.aResponse()
+        .withStatus(201)
+        .withBody("""{"journalpostId":"1415161718", "journalpostferdigstilt": false}""")
+    ))
 }
 
 private fun WireMockServer.stubIsReady() = also {
-    stubFor(
-        WireMock.get("$basePath/actuator/health/readiness")
-            .willReturn(
-                WireMock.aResponse()
-                    .withStatus(200)
-            )
-    )
-}
-
-private fun WireMockServer.stubKnyttTilAnnenSakK9() = also { wireMockServer ->
-    wireMockServer.stubFor(
-        WireMock.put(WireMock.urlMatching(".*$journalpostPath.*"))
-            .withHeader("Authorization", RegexPattern("^Bearer .+$"))
-            .withHeader("Content-Type", WireMock.equalTo("application/json"))
-            .withHeader("Accept", WireMock.equalTo("application/json"))
-            .withHeader("Nav-Consumer-Id", WireMock.equalTo("omsorgspenger-journalforing"))
-            .withHeader("Nav-Callid", AnythingPattern())
-            .withRequestBody(WireMock.matchingJsonPath("$.sakstype", WireMock.equalTo("FAGSAK")))
-            .withRequestBody(WireMock.matchingJsonPath("$.fagsaksystem", WireMock.equalTo("K9")))
-            .withRequestBody(WireMock.matchingJsonPath("$.tema", WireMock.equalTo("OMS")))
-            .withRequestBody(WireMock.matchingJsonPath("$.journalfoerendeEnhet", WireMock.equalTo("9999")))
-            .withRequestBody(WireMock.matchingJsonPath("$.bruker.idType", WireMock.equalTo("FNR")))
-            .withRequestBody(WireMock.matchingJsonPath("$.bruker.id"))
-            .willReturn(WireMock.aResponse().withStatus(200).withBody("""{"nyJournalpostId":"123412341234"}"""))
+    stubFor(WireMock.get("$basePath/actuator/health/readiness")
+        .willReturn(WireMock.aResponse()
+            .withStatus(200)
+        )
     )
 }
 
 internal fun WireMockServer.stubDokarkiv() =
     stubOppdaterJournalpostOk()
-        .stubOppdaterJournalpostUventetFeil()
-        .stubOppdaterJournalpostAlleredeFerdigstilt()
-        .stubFerdigstillJournalpostOk()
-        .stubFerdigstillJournalpostUventetFeil()
-        .stubOpprettJournalpostOk()
-        .stubOpprettJournalpostAlleredeOpprettet()
-        .stubOpprettJournalpostIkkeFerdigstilt()
-        .stubIsReady()
-        .stubKnyttTilAnnenSakK9()
+    .stubOppdaterJournalpostUventetFeil()
+    .stubOppdaterJournalpostAlleredeFerdigstilt()
+    .stubFerdigstillJournalpostOk()
+    .stubFerdigstillJournalpostUventetFeil()
+    .stubOpprettJournalpostOk()
+    .stubOpprettJournalpostAlleredeOpprettet()
+    .stubOpprettJournalpostIkkeFerdigstilt()
+    .stubIsReady()
 
 internal fun WireMockServer.dokarkivBaseUrl() = baseUrl() + basePath

--- a/src/test/kotlin/no/nav/omsorgspenger/testutils/wiremock/DokarkivproxyMock.kt
+++ b/src/test/kotlin/no/nav/omsorgspenger/testutils/wiremock/DokarkivproxyMock.kt
@@ -1,0 +1,38 @@
+package no.nav.omsorgspenger.testutils.wiremock
+
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.WireMock
+import com.github.tomakehurst.wiremock.matching.AnythingPattern
+import com.github.tomakehurst.wiremock.matching.RegexPattern
+
+private const val basePath = "/dokarkivproxy-mock"
+private const val journalpostPath = "$basePath/rest/journalpostapi/v1/journalpost/.*"
+
+private fun WireMockServer.stubKnyttTilAnnenSakK9() = also { wireMockServer ->
+    wireMockServer.stubFor(WireMock.put(WireMock.urlMatching(".*$journalpostPath.*"))
+        .withHeader("Authorization", RegexPattern("^Bearer .+$"))
+        .withHeader("Content-Type", WireMock.equalTo("application/json"))
+        .withHeader("Accept", WireMock.equalTo("application/json"))
+        .withHeader("Nav-Consumer-Id", WireMock.equalTo("omsorgspenger-journalforing"))
+        .withHeader("Nav-Callid", AnythingPattern())
+        .withRequestBody(WireMock.matchingJsonPath("$.sakstype", WireMock.equalTo("FAGSAK")))
+        .withRequestBody(WireMock.matchingJsonPath("$.fagsaksystem", WireMock.equalTo("K9")))
+        .withRequestBody(WireMock.matchingJsonPath("$.tema", WireMock.equalTo("OMS")))
+        .withRequestBody(WireMock.matchingJsonPath("$.journalfoerendeEnhet", WireMock.equalTo("9999")))
+        .withRequestBody(WireMock.matchingJsonPath("$.bruker.idType", WireMock.equalTo("FNR")))
+        .withRequestBody(WireMock.matchingJsonPath("$.bruker.id"))
+        .willReturn(WireMock.aResponse().withStatus(200).withBody("""{"nyJournalpostId":"123412341234"}""")))
+}
+
+private fun WireMockServer.stubIsReady() = also { wireMockServer ->
+    wireMockServer.stubFor(
+        WireMock.get("$basePath/isReady")
+        .willReturn(
+            WireMock.aResponse()
+            .withStatus(200)
+        )
+    )
+}
+
+internal fun WireMockServer.stubDokarkivproxy() = stubIsReady().stubKnyttTilAnnenSakK9()
+internal fun WireMockServer.dokarkivproxyBaseUrl() = baseUrl() + basePath


### PR DESCRIPTION
Reverts navikt/omsorgspenger-journalforing#150

`Access token på Authorization header er ikke er On-Behalf-Of-tokenDette betyr at vi ikke gjenkjenner tokenet som riktig type token utstedt av NAV sin Azure tenant. Vennligst forsøk på nytt med On-Behalf-Of flow access token fra NAV sin Azure tenant. Hvis ikke dette fungerer, kontakt oss på #team_dokumentløsninger`