### PR TITLE
Fjerner cooldown for docker-oppgraderinger

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -41,7 +41,5 @@ updates:
     directory: "/"
     schedule:
       interval: daily
-    cooldown:
-      default-days: 7
     registries:
       - ghcr


### PR DESCRIPTION
### Behov / Bakgrunn

Ønsker ikke cooldown på pakker/images vi bygger selv

### Løsning


### Andre endringer

